### PR TITLE
Add LFS check and warning dialog for large binaries during staging

### DIFF
--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -50,6 +50,7 @@ fn get_specta_builder() -> tauri_specta::Builder {
             crate::commands::unstage_hunk,
             crate::commands::discard_hunk,
             crate::commands::delete_file,
+            crate::commands::check_files_for_lfs,
             // Diff commands
             crate::commands::get_diff,
             crate::commands::get_diff_workdir,

--- a/src-tauri/src/models/settings.rs
+++ b/src-tauri/src/models/settings.rs
@@ -51,6 +51,10 @@ pub struct AppSettings {
 
     // Updates
     pub auto_update_enabled: bool,
+
+    // Large files
+    pub large_binary_warning_enabled: bool,
+    pub large_binary_threshold: u64, // in bytes, default 10MB
 }
 
 #[derive(Debug, Clone, Display, EnumString, Serialize, Deserialize, PartialEq, Default, Type)]
@@ -111,6 +115,10 @@ impl Default for AppSettings {
 
             // Updates
             auto_update_enabled: true,
+
+            // Large files
+            large_binary_warning_enabled: true,
+            large_binary_threshold: 10_485_760, // 10MB
         }
     }
 }
@@ -235,6 +243,10 @@ mod tests {
 
         // Updates
         assert!(settings.auto_update_enabled);
+
+        // Large files
+        assert!(settings.large_binary_warning_enabled);
+        assert_eq!(settings.large_binary_threshold, 10_485_760);
     }
 
     #[test]
@@ -266,6 +278,8 @@ mod tests {
             notification_history_capacity: 100,
             gravatar_enabled: true,
             auto_update_enabled: false,
+            large_binary_warning_enabled: false,
+            large_binary_threshold: 52_428_800,
         };
 
         assert_eq!(settings.theme, Theme::Dark);
@@ -285,6 +299,8 @@ mod tests {
         assert!(settings.ai_enabled);
         assert_eq!(settings.ai_provider, AiProvider::OpenAi);
         assert!(settings.gravatar_enabled);
+        assert!(!settings.large_binary_warning_enabled);
+        assert_eq!(settings.large_binary_threshold, 52_428_800);
     }
 
     #[test]
@@ -303,6 +319,14 @@ mod tests {
         );
         assert_eq!(deserialized.diff_context_lines, settings.diff_context_lines);
         assert_eq!(deserialized.ai_enabled, settings.ai_enabled);
+        assert_eq!(
+            deserialized.large_binary_warning_enabled,
+            settings.large_binary_warning_enabled
+        );
+        assert_eq!(
+            deserialized.large_binary_threshold,
+            settings.large_binary_threshold
+        );
     }
 
     #[test]

--- a/src/bindings/api.ts
+++ b/src/bindings/api.ts
@@ -102,6 +102,9 @@ async discardHunk(patch: string) : Promise<null> {
 async deleteFile(path: string) : Promise<null> {
     return await TAURI_INVOKE("delete_file", { path });
 },
+async checkFilesForLfs(paths: string[], threshold: number) : Promise<LfsCheckResult> {
+    return await TAURI_INVOKE("check_files_for_lfs", { paths, threshold });
+},
 /**
  * Get diff based on the specified target
  */
@@ -1371,7 +1374,7 @@ force: boolean;
  */
 detach: boolean }
 export type AiProvider = "OpenAi" | "Anthropic" | "Ollama"
-export type AppSettings = { theme: Theme; language: string; fontSize: number; showLineNumbers: boolean; autoFetchInterval: number; confirmBeforeDiscard: boolean; signCommits: boolean; bypassHooks: boolean; signingFormat: SigningFormat; signingKey: string | null; gpgProgram: string | null; sshProgram: string | null; diffContextLines: number; diffWordWrap: boolean; diffSideBySide: boolean; spellCheckCommitMessages: boolean; conventionalCommitsEnabled: boolean; conventionalCommitsScopes: string[] | null; aiEnabled: boolean; aiProvider: AiProvider; aiModel: string | null; aiOllamaUrl: string | null; defaultSshKey: string | null; notificationHistoryCapacity: number; gravatarEnabled: boolean; autoUpdateEnabled: boolean }
+export type AppSettings = { theme: Theme; language: string; fontSize: number; showLineNumbers: boolean; autoFetchInterval: number; confirmBeforeDiscard: boolean; signCommits: boolean; bypassHooks: boolean; signingFormat: SigningFormat; signingKey: string | null; gpgProgram: string | null; sshProgram: string | null; diffContextLines: number; diffWordWrap: boolean; diffSideBySide: boolean; spellCheckCommitMessages: boolean; conventionalCommitsEnabled: boolean; conventionalCommitsScopes: string[] | null; aiEnabled: boolean; aiProvider: AiProvider; aiModel: string | null; aiOllamaUrl: string | null; defaultSshKey: string | null; notificationHistoryCapacity: number; gravatarEnabled: boolean; autoUpdateEnabled: boolean; largeBinaryWarningEnabled: boolean; largeBinaryThreshold: number }
 /**
  * Options for applying mailbox patches (git am)
  */
@@ -2527,6 +2530,46 @@ export type IssueState = "Open" | "Closed" | "All"
  * Paginated issues response
  */
 export type IssuesPage = { items: Issue[]; hasMore: boolean }
+/**
+ * Information about a large binary file detected during staging
+ */
+export type LargeBinaryFileInfo = { 
+/**
+ * File path relative to repository root
+ */
+path: string; 
+/**
+ * File size in bytes
+ */
+size: number; 
+/**
+ * Whether the file is detected as binary
+ */
+isBinary: boolean; 
+/**
+ * Whether the file is already tracked by LFS
+ */
+isLfsTracked: boolean; 
+/**
+ * Suggested LFS tracking pattern (e.g., "*.psd")
+ */
+suggestedPattern: string }
+/**
+ * Result of checking files for LFS eligibility before staging
+ */
+export type LfsCheckResult = { 
+/**
+ * Large binary files that should be tracked with LFS
+ */
+files: LargeBinaryFileInfo[]; 
+/**
+ * Whether Git LFS is installed on the system
+ */
+lfsInstalled: boolean; 
+/**
+ * Whether LFS is initialized in this repository
+ */
+lfsInitialized: boolean }
 /**
  * LFS environment information
  */

--- a/src/components/branches/BranchContextMenu.tsx
+++ b/src/components/branches/BranchContextMenu.tsx
@@ -99,19 +99,19 @@ export function BranchContextMenu({ branch, children, onCheckout }: BranchContex
         <MenuItem icon={GitBranch} disabled={isCurrentBranch} onSelect={onCheckout}>
           {t('branches.contextMenu.checkout', { name: branch.name })}
         </MenuItem>
-        <MenuItem
-          icon={GitMerge}
-          disabled={isCurrentBranch}
-          onSelect={() => openMergeDialog({ sourceBranch: branch.name })}
-        >
-          {t('branches.contextMenu.mergeInto', {
-            source: branch.name,
-            target: currentBranch?.name ?? 'current',
-          })}
-        </MenuItem>
-        <MenuItem icon={GitMerge} disabled className="[&>svg]:rotate-180">
-          {t('branches.contextMenu.rebaseOnto', { name: branch.name })}
-        </MenuItem>
+        {!isCurrentBranch && (
+          <MenuItem icon={GitMerge} onSelect={() => openMergeDialog({ sourceBranch: branch.name })}>
+            {t('branches.contextMenu.mergeInto', {
+              source: branch.name,
+              target: currentBranch?.name ?? 'current',
+            })}
+          </MenuItem>
+        )}
+        {!isCurrentBranch && (
+          <MenuItem icon={GitMerge} disabled className="[&>svg]:rotate-180">
+            {t('branches.contextMenu.rebaseOnto', { name: branch.name })}
+          </MenuItem>
+        )}
         <MenuSeparator />
 
         {hasUpstream && isCurrentBranch && (

--- a/src/components/layout/AppLayout.test.tsx
+++ b/src/components/layout/AppLayout.test.tsx
@@ -149,6 +149,11 @@ vi.mock('../staging/DiscardConfirmDialog', () => ({
   },
 }));
 
+vi.mock('../staging/LargeBinaryWarningDialog', () => ({
+  LargeBinaryWarningDialog: (props: Record<string, unknown>) =>
+    props.isOpen ? <div data-testid="large-binary-warning-dialog">LargeBinaryWarning</div> : null,
+}));
+
 vi.mock('../settings/SettingsDialog', () => ({
   SettingsDialog: (props: Record<string, unknown>) =>
     props.isOpen ? <div data-testid="settings-dialog">Settings</div> : null,
@@ -205,6 +210,7 @@ const mockCloseRenameBranchDialog = vi.fn();
 const mockCloseBranchCompareDialog = vi.fn();
 const mockCloseStashDialog = vi.fn();
 const mockCloseDiscardConfirmDialog = vi.fn();
+const mockCloseLargeBinaryWarningDialog = vi.fn();
 const mockCloseSettingsDialog = vi.fn();
 const mockCloseRepositorySettingsDialog = vi.fn();
 const mockClosePassphraseDialog = vi.fn();
@@ -302,6 +308,16 @@ let mockDialogStore = {
     onConfirm: null as (() => void) | null,
   },
   closeDiscardConfirmDialog: mockCloseDiscardConfirmDialog,
+  largeBinaryWarningDialog: {
+    isOpen: false,
+    files: [],
+    pendingPaths: [],
+    lfsInstalled: false,
+    lfsInitialized: false,
+    onStageAnyway: null as (() => void) | null,
+    onTrackWithLfs: null as ((patterns: string[]) => void) | null,
+  },
+  closeLargeBinaryWarningDialog: mockCloseLargeBinaryWarningDialog,
   settingsDialog: { isOpen: false },
   closeSettingsDialog: mockCloseSettingsDialog,
   passphraseDialog: {
@@ -402,6 +418,16 @@ describe('AppLayout', () => {
       closeStashDialog: mockCloseStashDialog,
       discardConfirmDialog: { isOpen: false, mode: 'file', filePath: null, onConfirm: null },
       closeDiscardConfirmDialog: mockCloseDiscardConfirmDialog,
+      largeBinaryWarningDialog: {
+        isOpen: false,
+        files: [],
+        pendingPaths: [],
+        lfsInstalled: false,
+        lfsInitialized: false,
+        onStageAnyway: null,
+        onTrackWithLfs: null,
+      },
+      closeLargeBinaryWarningDialog: mockCloseLargeBinaryWarningDialog,
       settingsDialog: { isOpen: false },
       closeSettingsDialog: mockCloseSettingsDialog,
       passphraseDialog: { isOpen: false, keyPath: null, onSuccess: null, onCancel: null },

--- a/src/components/layout/AppLayout.tsx
+++ b/src/components/layout/AppLayout.tsx
@@ -29,6 +29,7 @@ import { BisectDialog } from '../merge/BisectDialog';
 import { FetchDialog, PushDialog, PullDialog, PassphraseDialog } from '../remotes';
 import { StashDialog } from '../stash/StashDialog';
 import { DiscardConfirmDialog } from '../staging/DiscardConfirmDialog';
+import { LargeBinaryWarningDialog } from '../staging/LargeBinaryWarningDialog';
 import { SettingsDialog } from '../settings/SettingsDialog';
 import { RepositorySettingsDialog } from '../settings/RepositorySettingsDialog';
 import { useRepositoryStore } from '../../store/repositoryStore';
@@ -92,6 +93,8 @@ export function AppLayout({ children }: AppLayoutProps) {
     closeStashDialog,
     discardConfirmDialog,
     closeDiscardConfirmDialog,
+    largeBinaryWarningDialog,
+    closeLargeBinaryWarningDialog,
     settingsDialog,
     closeSettingsDialog,
     repositorySettingsDialog,
@@ -296,6 +299,21 @@ export function AppLayout({ children }: AppLayoutProps) {
         onConfirm={() => {
           discardConfirmDialog.onConfirm?.();
           closeDiscardConfirmDialog();
+        }}
+      />
+      <LargeBinaryWarningDialog
+        isOpen={largeBinaryWarningDialog.isOpen}
+        onClose={closeLargeBinaryWarningDialog}
+        files={largeBinaryWarningDialog.files}
+        lfsInstalled={largeBinaryWarningDialog.lfsInstalled}
+        lfsInitialized={largeBinaryWarningDialog.lfsInitialized}
+        onStageAnyway={() => {
+          largeBinaryWarningDialog.onStageAnyway?.();
+          closeLargeBinaryWarningDialog();
+        }}
+        onTrackWithLfs={(patterns) => {
+          largeBinaryWarningDialog.onTrackWithLfs?.(patterns);
+          closeLargeBinaryWarningDialog();
         }}
       />
       <SettingsDialog isOpen={settingsDialog.isOpen} onClose={closeSettingsDialog} />

--- a/src/components/settings/SettingsDialog.test.tsx
+++ b/src/components/settings/SettingsDialog.test.tsx
@@ -104,6 +104,8 @@ const mockSettings = {
   defaultSshKey: null,
   gravatarEnabled: false,
   autoUpdateEnabled: true,
+  largeBinaryWarningEnabled: true,
+  largeBinaryThreshold: 10485760,
 };
 
 describe('SettingsDialog', () => {
@@ -344,5 +346,22 @@ describe('SettingsDialog', () => {
 
     expect(screen.queryByText("You're on the latest version")).not.toBeInTheDocument();
     expect(screen.queryByText(/Update v/)).not.toBeInTheDocument();
+  });
+
+  it('should show large files settings on Git tab', async () => {
+    render(<SettingsDialog isOpen={true} onClose={() => {}} />);
+
+    await waitFor(() => {
+      expect(screen.getByText('Settings')).toBeInTheDocument();
+    });
+
+    // Click on Git tab
+    fireEvent.click(screen.getByText('Git'));
+
+    await waitFor(() => {
+      expect(screen.getByText('Large Files')).toBeInTheDocument();
+      expect(screen.getByText('Warn about large binary files')).toBeInTheDocument();
+      expect(screen.getByText('Size threshold')).toBeInTheDocument();
+    });
   });
 });

--- a/src/components/settings/SettingsDialog.tsx
+++ b/src/components/settings/SettingsDialog.tsx
@@ -80,6 +80,8 @@ const DEFAULT_SETTINGS: AppSettings = {
   defaultSshKey: null,
   gravatarEnabled: false,
   autoUpdateEnabled: true,
+  largeBinaryWarningEnabled: true,
+  largeBinaryThreshold: 10485760,
 };
 
 export function SettingsDialog({ isOpen, onClose, onSettingsChange }: SettingsDialogProps) {
@@ -571,6 +573,39 @@ function GitSettings({ settings, updateSetting }: SettingsPanelProps) {
             {t('settings.git.defaultSshKey.autoDescription')}
           </p>
         )}
+      </FormField>
+
+      <h3 className={sectionTitleClass}>{t('settings.git.largeFiles.title')}</h3>
+
+      <div className={groupClass}>
+        <CheckboxField
+          id="large-binary-warning"
+          label={t('settings.git.largeFiles.warningEnabled.label')}
+          description={t('settings.git.largeFiles.warningEnabled.description')}
+          checked={settings.largeBinaryWarningEnabled}
+          onCheckedChange={(checked) =>
+            updateSetting('largeBinaryWarningEnabled', checked === true)
+          }
+        />
+      </div>
+
+      <FormField
+        label={t('settings.git.largeFiles.threshold.label')}
+        htmlFor="largeBinaryThreshold"
+        hint={t('settings.git.largeFiles.threshold.hint')}
+      >
+        <Select
+          id="largeBinaryThreshold"
+          value={String(settings.largeBinaryThreshold)}
+          onValueChange={(value) => updateSetting('largeBinaryThreshold', parseInt(value))}
+        >
+          <SelectItem value="524288">512 KB</SelectItem>
+          <SelectItem value="1048576">1 MB</SelectItem>
+          <SelectItem value="5242880">5 MB</SelectItem>
+          <SelectItem value="10485760">10 MB</SelectItem>
+          <SelectItem value="52428800">50 MB</SelectItem>
+          <SelectItem value="104857600">100 MB</SelectItem>
+        </Select>
       </FormField>
 
       <h3 className={sectionTitleClass}>{t('settings.signing.title')}</h3>

--- a/src/components/staging/LargeBinaryWarningDialog.test.tsx
+++ b/src/components/staging/LargeBinaryWarningDialog.test.tsx
@@ -1,0 +1,214 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { LargeBinaryWarningDialog } from './LargeBinaryWarningDialog';
+import type { LargeBinaryFileInfo } from '@/types';
+
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({
+    t: (key: string, opts?: Record<string, unknown>) => {
+      if (opts?.count !== undefined && opts?.threshold)
+        return `${key}: ${opts.count} files, ${opts.threshold}`;
+      if (opts?.pattern) return `${key}: ${opts.pattern}`;
+      return key;
+    },
+  }),
+}));
+
+vi.mock('@/services/api', () => ({
+  shellApi: {
+    openUrl: vi.fn(),
+  },
+}));
+
+const mockFiles: LargeBinaryFileInfo[] = [
+  {
+    path: 'assets/image.psd',
+    size: 15728640,
+    isBinary: true,
+    isLfsTracked: false,
+    suggestedPattern: '*.psd',
+  },
+  {
+    path: 'assets/video.mp4',
+    size: 52428800,
+    isBinary: true,
+    isLfsTracked: false,
+    suggestedPattern: '*.mp4',
+  },
+];
+
+describe('LargeBinaryWarningDialog', () => {
+  const defaultProps = {
+    isOpen: true,
+    onClose: vi.fn(),
+    files: mockFiles,
+    lfsInstalled: true,
+    lfsInitialized: true,
+    onStageAnyway: vi.fn(),
+    onTrackWithLfs: vi.fn(),
+  };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('should render when open', () => {
+    render(<LargeBinaryWarningDialog {...defaultProps} />);
+
+    expect(screen.getByText('staging.lfsWarning.title')).toBeInTheDocument();
+  });
+
+  it('should not render when closed', () => {
+    render(<LargeBinaryWarningDialog {...defaultProps} isOpen={false} />);
+
+    expect(screen.queryByText('staging.lfsWarning.title')).not.toBeInTheDocument();
+  });
+
+  it('should display all files in the list', () => {
+    render(<LargeBinaryWarningDialog {...defaultProps} />);
+
+    expect(screen.getByText('assets/image.psd')).toBeInTheDocument();
+    expect(screen.getByText('assets/video.mp4')).toBeInTheDocument();
+  });
+
+  it('should display suggested patterns for each file', () => {
+    render(<LargeBinaryWarningDialog {...defaultProps} />);
+
+    expect(screen.getByText('staging.lfsWarning.suggestedPattern: *.psd')).toBeInTheDocument();
+    expect(screen.getByText('staging.lfsWarning.suggestedPattern: *.mp4')).toBeInTheDocument();
+  });
+
+  it('should show warning message with file count', () => {
+    render(<LargeBinaryWarningDialog {...defaultProps} />);
+
+    // The message includes count and threshold
+    expect(screen.getByText(/staging.lfsWarning.message/)).toBeInTheDocument();
+  });
+
+  it('should call onStageAnyway and onClose when stage anyway is clicked', () => {
+    render(<LargeBinaryWarningDialog {...defaultProps} />);
+
+    const stageAnywayButton = screen.getByText('staging.lfsWarning.stageAnyway');
+    fireEvent.click(stageAnywayButton);
+
+    expect(defaultProps.onStageAnyway).toHaveBeenCalledTimes(1);
+    expect(defaultProps.onClose).toHaveBeenCalledTimes(1);
+  });
+
+  it('should call onTrackWithLfs with unique patterns and onClose when track with LFS is clicked', () => {
+    render(<LargeBinaryWarningDialog {...defaultProps} />);
+
+    const trackButton = screen.getByText('staging.lfsWarning.trackWithLfs');
+    fireEvent.click(trackButton);
+
+    expect(defaultProps.onTrackWithLfs).toHaveBeenCalledWith(['*.psd', '*.mp4']);
+    expect(defaultProps.onClose).toHaveBeenCalledTimes(1);
+  });
+
+  it('should deduplicate patterns when calling onTrackWithLfs', () => {
+    const filesWithDuplicatePatterns: LargeBinaryFileInfo[] = [
+      {
+        path: 'assets/image1.psd',
+        size: 15728640,
+        isBinary: true,
+        isLfsTracked: false,
+        suggestedPattern: '*.psd',
+      },
+      {
+        path: 'assets/image2.psd',
+        size: 20971520,
+        isBinary: true,
+        isLfsTracked: false,
+        suggestedPattern: '*.psd',
+      },
+    ];
+
+    render(<LargeBinaryWarningDialog {...defaultProps} files={filesWithDuplicatePatterns} />);
+
+    const trackButton = screen.getByText('staging.lfsWarning.trackWithLfs');
+    fireEvent.click(trackButton);
+
+    expect(defaultProps.onTrackWithLfs).toHaveBeenCalledWith(['*.psd']);
+  });
+
+  it('should show Track with LFS button when LFS is installed', () => {
+    render(<LargeBinaryWarningDialog {...defaultProps} lfsInstalled={true} />);
+
+    expect(screen.getByText('staging.lfsWarning.trackWithLfs')).toBeInTheDocument();
+  });
+
+  it('should hide Track with LFS button when LFS is not installed', () => {
+    render(<LargeBinaryWarningDialog {...defaultProps} lfsInstalled={false} />);
+
+    expect(screen.queryByText('staging.lfsWarning.trackWithLfs')).not.toBeInTheDocument();
+  });
+
+  it('should show LFS not installed info when LFS is not installed', () => {
+    render(<LargeBinaryWarningDialog {...defaultProps} lfsInstalled={false} />);
+
+    expect(screen.getByText('staging.lfsWarning.lfsNotInstalled')).toBeInTheDocument();
+    expect(screen.getByText('staging.lfsWarning.installLfs')).toBeInTheDocument();
+  });
+
+  it('should not show LFS not installed info when LFS is installed', () => {
+    render(<LargeBinaryWarningDialog {...defaultProps} lfsInstalled={true} />);
+
+    expect(screen.queryByText('staging.lfsWarning.lfsNotInstalled')).not.toBeInTheDocument();
+  });
+
+  it('should open LFS install URL when install link is clicked', async () => {
+    const { shellApi } = await import('@/services/api');
+
+    render(<LargeBinaryWarningDialog {...defaultProps} lfsInstalled={false} />);
+
+    const installLink = screen.getByText('staging.lfsWarning.installLfs');
+    fireEvent.click(installLink);
+
+    expect(shellApi.openUrl).toHaveBeenCalledWith('https://git-lfs.com');
+  });
+
+  it('should show cancel button', () => {
+    render(<LargeBinaryWarningDialog {...defaultProps} />);
+
+    expect(screen.getByText('common.cancel')).toBeInTheDocument();
+  });
+
+  it('should always show stage anyway button', () => {
+    render(<LargeBinaryWarningDialog {...defaultProps} />);
+
+    const stageAnywayButton = screen.getByText('staging.lfsWarning.stageAnyway');
+    expect(stageAnywayButton).toBeInTheDocument();
+    expect(stageAnywayButton.closest('button')).not.toBeDisabled();
+  });
+
+  it('should show stage anyway button even when LFS is not installed', () => {
+    render(<LargeBinaryWarningDialog {...defaultProps} lfsInstalled={false} />);
+
+    expect(screen.getByText('staging.lfsWarning.stageAnyway')).toBeInTheDocument();
+  });
+
+  it('should hide Track with LFS button when onTrackWithLfs is not provided', () => {
+    render(
+      <LargeBinaryWarningDialog {...defaultProps} lfsInstalled={true} onTrackWithLfs={undefined} />
+    );
+
+    expect(screen.queryByText('staging.lfsWarning.trackWithLfs')).not.toBeInTheDocument();
+  });
+
+  it('should render single file correctly', () => {
+    const singleFile: LargeBinaryFileInfo[] = [
+      {
+        path: 'model.bin',
+        size: 104857600,
+        isBinary: true,
+        isLfsTracked: false,
+        suggestedPattern: '*.bin',
+      },
+    ];
+
+    render(<LargeBinaryWarningDialog {...defaultProps} files={singleFile} />);
+
+    expect(screen.getByText('model.bin')).toBeInTheDocument();
+    expect(screen.getByText('staging.lfsWarning.suggestedPattern: *.bin')).toBeInTheDocument();
+  });
+});

--- a/src/components/staging/LargeBinaryWarningDialog.tsx
+++ b/src/components/staging/LargeBinaryWarningDialog.tsx
@@ -1,0 +1,127 @@
+import { useTranslation } from 'react-i18next';
+import { AlertTriangle, ExternalLink } from 'lucide-react';
+import {
+  Dialog,
+  DialogContent,
+  DialogTitle,
+  DialogBody,
+  DialogFooter,
+  DialogClose,
+  Button,
+  Alert,
+} from '@/components/ui';
+import { shellApi } from '@/services/api';
+import type { LargeBinaryFileInfo } from '@/types';
+
+interface LargeBinaryWarningDialogProps {
+  isOpen: boolean;
+  onClose: () => void;
+  files: LargeBinaryFileInfo[];
+  lfsInstalled: boolean;
+  lfsInitialized: boolean;
+  onStageAnyway: () => void;
+  onTrackWithLfs?: (patterns: string[]) => void;
+}
+
+function formatSize(bytes: number): string {
+  if (bytes < 1024) return `${bytes} B`;
+  if (bytes < 1024 * 1024) return `${(bytes / 1024).toFixed(1)} KB`;
+  if (bytes < 1024 * 1024 * 1024) return `${(bytes / (1024 * 1024)).toFixed(1)} MB`;
+  return `${(bytes / (1024 * 1024 * 1024)).toFixed(1)} GB`;
+}
+
+export function LargeBinaryWarningDialog({
+  isOpen,
+  onClose,
+  files,
+  lfsInstalled,
+  onStageAnyway,
+  onTrackWithLfs,
+}: LargeBinaryWarningDialogProps) {
+  const { t } = useTranslation();
+
+  const handleStageAnyway = () => {
+    onStageAnyway();
+    onClose();
+  };
+
+  const handleTrackWithLfs = () => {
+    const patterns = [...new Set(files.map((f) => f.suggestedPattern))];
+    onTrackWithLfs?.(patterns);
+    onClose();
+  };
+
+  const handleInstallLfs = () => {
+    shellApi.openUrl('https://git-lfs.com');
+  };
+
+  // Use the smallest file size as approximate threshold display
+  const minFileSize = Math.min(...files.map((f) => f.size));
+  const threshold = formatSize(minFileSize);
+
+  return (
+    <Dialog open={isOpen} onOpenChange={(open) => !open && onClose()}>
+      <DialogContent className="max-w-120">
+        <DialogTitle icon={AlertTriangle} iconClassName="text-warning">
+          {t('staging.lfsWarning.title')}
+        </DialogTitle>
+
+        <DialogBody className="flex flex-col gap-3">
+          <Alert variant="warning">
+            {t('staging.lfsWarning.message', { count: files.length, threshold })}
+          </Alert>
+
+          {/* File list */}
+          <div className="max-h-48 overflow-y-auto rounded border border-(--border-color)">
+            {files.map((file) => (
+              <div
+                key={file.path}
+                className="flex items-center justify-between px-3 py-2 text-sm border-b border-(--border-color) last:border-b-0"
+              >
+                <span className="truncate text-(--text-primary) mr-2">{file.path}</span>
+                <div className="flex items-center gap-2 shrink-0">
+                  <span className="text-(--text-secondary)">{formatSize(file.size)}</span>
+                  <span className="text-xs text-(--text-muted)">
+                    {t('staging.lfsWarning.suggestedPattern', {
+                      pattern: file.suggestedPattern,
+                    })}
+                  </span>
+                </div>
+              </div>
+            ))}
+          </div>
+
+          {/* LFS not installed info */}
+          {!lfsInstalled && (
+            <Alert variant="info">
+              <div className="flex flex-col gap-1">
+                <span>{t('staging.lfsWarning.lfsNotInstalled')}</span>
+                <button
+                  className="inline-flex items-center gap-1 text-sm font-medium text-(--accent-color) hover:underline cursor-pointer self-start"
+                  onClick={handleInstallLfs}
+                >
+                  {t('staging.lfsWarning.installLfs')}
+                  <ExternalLink className="size-3" />
+                </button>
+              </div>
+            </Alert>
+          )}
+        </DialogBody>
+
+        <DialogFooter>
+          <DialogClose asChild>
+            <Button variant="secondary">{t('common.cancel')}</Button>
+          </DialogClose>
+          {lfsInstalled && onTrackWithLfs && (
+            <Button variant="primary" onClick={handleTrackWithLfs}>
+              {t('staging.lfsWarning.trackWithLfs')}
+            </Button>
+          )}
+          <Button variant="destructive" onClick={handleStageAnyway}>
+            {t('staging.lfsWarning.stageAnyway')}
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -351,6 +351,17 @@
         "hint": "SSH key to use for remote operations when no per-remote key is configured",
         "auto": "Auto (system default)",
         "autoDescription": "Let Git and SSH agent decide which key to use"
+      },
+      "largeFiles": {
+        "title": "Large Files",
+        "warningEnabled": {
+          "label": "Warn about large binary files",
+          "description": "Show a warning dialog when staging binary files that exceed the size threshold"
+        },
+        "threshold": {
+          "label": "Size threshold",
+          "hint": "Files larger than this will trigger a warning"
+        }
       }
     }
   },
@@ -677,6 +688,15 @@
     },
     "referenceMention": {
       "noMatches": "No matching issues or PRs"
+    },
+    "lfsWarning": {
+      "title": "Large Binary Files Detected",
+      "message": "{{count}} file(s) exceed the size threshold ({{threshold}}). Consider using Git LFS for better performance.",
+      "stageAnyway": "Stage Anyway",
+      "trackWithLfs": "Track with LFS",
+      "lfsNotInstalled": "Large binary files can slow down cloning, fetching, and increase repository size. Git LFS stores them efficiently outside the main repo.",
+      "installLfs": "Install Git LFS",
+      "suggestedPattern": "Suggested pattern: {{pattern}}"
     }
   },
   "merge": {

--- a/src/services/api.ts
+++ b/src/services/api.ts
@@ -192,6 +192,9 @@ export const stagingApi = {
   unstageHunk: (patch: string) => commands.unstageHunk(patch),
 
   discardHunk: (patch: string) => commands.discardHunk(patch),
+
+  checkFilesForLfs: (paths: string[], threshold: number) =>
+    commands.checkFilesForLfs(paths, threshold),
 };
 
 export const diffApi = {

--- a/src/store/dialogStore.test.ts
+++ b/src/store/dialogStore.test.ts
@@ -86,6 +86,15 @@ describe('dialogStore', () => {
       settingsDialog: { isOpen: false },
       repositorySettingsDialog: { isOpen: false },
       mergeDialog: { isOpen: false, sourceBranch: undefined, onMergeComplete: undefined },
+      largeBinaryWarningDialog: {
+        isOpen: false,
+        files: [],
+        pendingPaths: [],
+        lfsInstalled: false,
+        lfsInitialized: false,
+        onStageAnyway: undefined,
+        onTrackWithLfs: undefined,
+      },
     });
   });
 
@@ -524,6 +533,59 @@ describe('dialogStore', () => {
       const dialog = useDialogStore.getState().mergeDialog;
       expect(dialog.isOpen).toBe(false);
       expect(dialog.sourceBranch).toBeUndefined();
+    });
+  });
+
+  describe('largeBinaryWarningDialog', () => {
+    const mockFiles = [
+      {
+        path: 'assets/image.psd',
+        size: 15728640,
+        isBinary: true,
+        isLfsTracked: false,
+        suggestedPattern: '*.psd',
+      },
+    ];
+
+    it('should open large binary warning dialog with options', () => {
+      const onStageAnyway = vi.fn();
+      const onTrackWithLfs = vi.fn();
+      useDialogStore.getState().openLargeBinaryWarningDialog({
+        files: mockFiles,
+        pendingPaths: ['assets/image.psd'],
+        lfsInstalled: true,
+        lfsInitialized: true,
+        onStageAnyway,
+        onTrackWithLfs,
+      });
+
+      const dialog = useDialogStore.getState().largeBinaryWarningDialog;
+      expect(dialog.isOpen).toBe(true);
+      expect(dialog.files).toEqual(mockFiles);
+      expect(dialog.pendingPaths).toEqual(['assets/image.psd']);
+      expect(dialog.lfsInstalled).toBe(true);
+      expect(dialog.lfsInitialized).toBe(true);
+      expect(dialog.onStageAnyway).toBe(onStageAnyway);
+      expect(dialog.onTrackWithLfs).toBe(onTrackWithLfs);
+    });
+
+    it('should close large binary warning dialog and reset state', () => {
+      useDialogStore.getState().openLargeBinaryWarningDialog({
+        files: mockFiles,
+        pendingPaths: ['assets/image.psd'],
+        lfsInstalled: true,
+        lfsInitialized: false,
+      });
+      useDialogStore.getState().closeLargeBinaryWarningDialog();
+
+      const dialog = useDialogStore.getState().largeBinaryWarningDialog;
+      expect(dialog.isOpen).toBe(false);
+      expect(dialog.files).toEqual([]);
+      expect(dialog.pendingPaths).toEqual([]);
+      expect(dialog.lfsInstalled).toBe(false);
+      expect(dialog.lfsInitialized).toBe(false);
+      expect(dialog.onStageAnyway).toBeUndefined();
+      expect(dialog.onTrackWithLfs).toBeUndefined();
     });
   });
 });

--- a/src/store/dialogStore.ts
+++ b/src/store/dialogStore.ts
@@ -5,6 +5,7 @@ import type {
   Branch,
   Commit,
   CherryPickResult,
+  LargeBinaryFileInfo,
   MergeResult,
   RebaseResult,
   ResetMode,
@@ -158,6 +159,17 @@ interface MergeDialogState {
   onMergeComplete?: (result: MergeResult) => void;
 }
 
+// Large binary warning dialog state
+interface LargeBinaryWarningDialogState {
+  isOpen: boolean;
+  files: LargeBinaryFileInfo[];
+  pendingPaths: string[];
+  lfsInstalled: boolean;
+  lfsInitialized: boolean;
+  onStageAnyway?: () => void;
+  onTrackWithLfs?: (patterns: string[]) => void;
+}
+
 // Passphrase dialog state
 interface PassphraseDialogState {
   isOpen: boolean;
@@ -232,6 +244,9 @@ interface DialogState {
 
   // Merge dialog
   mergeDialog: MergeDialogState;
+
+  // Large binary warning dialog
+  largeBinaryWarningDialog: LargeBinaryWarningDialogState;
 
   // Passphrase dialog
   passphraseDialog: PassphraseDialogState;
@@ -358,6 +373,17 @@ interface DialogState {
     onMergeComplete?: (result: MergeResult) => void;
   }) => void;
   closeMergeDialog: () => void;
+
+  // Large binary warning dialog actions
+  openLargeBinaryWarningDialog: (options: {
+    files: LargeBinaryFileInfo[];
+    pendingPaths: string[];
+    lfsInstalled: boolean;
+    lfsInitialized: boolean;
+    onStageAnyway?: () => void;
+    onTrackWithLfs?: (patterns: string[]) => void;
+  }) => void;
+  closeLargeBinaryWarningDialog: () => void;
 
   // Passphrase dialog actions
   openPassphraseDialog: (options: {
@@ -490,6 +516,16 @@ const initialMergeDialogState: MergeDialogState = {
   onMergeComplete: undefined,
 };
 
+const initialLargeBinaryWarningDialogState: LargeBinaryWarningDialogState = {
+  isOpen: false,
+  files: [],
+  pendingPaths: [],
+  lfsInstalled: false,
+  lfsInitialized: false,
+  onStageAnyway: undefined,
+  onTrackWithLfs: undefined,
+};
+
 const initialPassphraseDialogState: PassphraseDialogState = {
   isOpen: false,
   keyPath: null,
@@ -520,6 +556,7 @@ export const useDialogStore = create<DialogState>((set) => ({
   settingsDialog: initialSettingsDialogState,
   repositorySettingsDialog: initialRepositorySettingsDialogState,
   mergeDialog: initialMergeDialogState,
+  largeBinaryWarningDialog: initialLargeBinaryWarningDialogState,
   passphraseDialog: initialPassphraseDialogState,
 
   openTagDialog: (options) => {
@@ -790,6 +827,24 @@ export const useDialogStore = create<DialogState>((set) => ({
 
   closeMergeDialog: () => {
     set({ mergeDialog: initialMergeDialogState });
+  },
+
+  openLargeBinaryWarningDialog: (options) => {
+    set({
+      largeBinaryWarningDialog: {
+        isOpen: true,
+        files: options.files,
+        pendingPaths: options.pendingPaths,
+        lfsInstalled: options.lfsInstalled,
+        lfsInitialized: options.lfsInitialized,
+        onStageAnyway: options.onStageAnyway,
+        onTrackWithLfs: options.onTrackWithLfs,
+      },
+    });
+  },
+
+  closeLargeBinaryWarningDialog: () => {
+    set({ largeBinaryWarningDialog: initialLargeBinaryWarningDialogState });
   },
 
   openPassphraseDialog: (options) => {

--- a/src/store/settingsStore.test.ts
+++ b/src/store/settingsStore.test.ts
@@ -54,6 +54,8 @@ describe('settingsStore', () => {
     notificationHistoryCapacity: 50,
     gravatarEnabled: false,
     autoUpdateEnabled: true,
+    largeBinaryWarningEnabled: true,
+    largeBinaryThreshold: 10485760,
   };
 
   beforeEach(() => {

--- a/src/store/settingsStore.ts
+++ b/src/store/settingsStore.ts
@@ -44,6 +44,8 @@ const DEFAULT_SETTINGS: AppSettings = {
   notificationHistoryCapacity: 50,
   gravatarEnabled: false,
   autoUpdateEnabled: true,
+  largeBinaryWarningEnabled: true,
+  largeBinaryThreshold: 10485760,
 };
 
 export const useSettingsStore = create<SettingsState>((set, get) => ({

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -201,6 +201,8 @@ export type {
   GitEnvironment,
   LfsPruneOptions,
   LfsPruneResult,
+  LargeBinaryFileInfo,
+  LfsCheckResult,
 
   // Progress types
   GitOperationProgressEvent,


### PR DESCRIPTION
This PR introduces a new command to check for large binary files during the staging process, along with a warning dialog to inform users. This enhancement aims to improve user experience by preventing accidental staging of large files that may not be suitable for version control.

- Implemented LFS check command for large binary files
- Added warning dialog to alert users during staging of large files
- Updated relevant components and services to support the new functionality
- Added tests for the new LargeBinaryWarningDialog component
- Modified localization files to include new dialog messages