### PR TITLE
Implement pinning functionality for recent repositories

### DIFF
--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -328,6 +328,7 @@ dependencies = [
  "bytes",
  "bzip2",
  "chrono",
+ "dirs",
  "dotenvy_macro",
  "env_logger",
  "flate2",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -61,6 +61,7 @@ sha2 = "0.10"
 md-5 = "0.10"
 rand = "0.8"
 secrecy = "0.10"
+dirs = "6"
 async-trait = "0.1"
 reqwest = { version = "0.12", features = ["json", "rustls-tls"] }
 

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -30,6 +30,8 @@ fn get_specta_builder() -> tauri_specta::Builder {
             crate::commands::get_commit,
             crate::commands::get_recent_repositories,
             crate::commands::remove_recent_repository,
+            crate::commands::pin_repository,
+            crate::commands::unpin_repository,
             crate::commands::show_in_folder,
             crate::commands::open_url,
             crate::commands::open_terminal,

--- a/src/bindings/api.ts
+++ b/src/bindings/api.ts
@@ -45,6 +45,12 @@ async getRecentRepositories() : Promise<RecentRepository[]> {
 async removeRecentRepository(path: string) : Promise<null> {
     return await TAURI_INVOKE("remove_recent_repository", { path });
 },
+async pinRepository(path: string) : Promise<null> {
+    return await TAURI_INVOKE("pin_repository", { path });
+},
+async unpinRepository(path: string) : Promise<null> {
+    return await TAURI_INVOKE("unpin_repository", { path });
+},
 async showInFolder(path: string) : Promise<null> {
     return await TAURI_INVOKE("show_in_folder", { path });
 },
@@ -3184,7 +3190,7 @@ shortOid: string;
  * Commit summary
  */
 summary: string }
-export type RecentRepository = { path: string; name: string; lastOpened: string }
+export type RecentRepository = { path: string; name: string; lastOpened: string; exists: boolean; currentBranch: string | null; isPinned: boolean; displayPath: string }
 /**
  * A ref (branch, tag) changed
  */

--- a/src/components/WelcomeView.test.tsx
+++ b/src/components/WelcomeView.test.tsx
@@ -10,11 +10,15 @@ vi.mock('react-i18next', () => ({
 
 const mockLoadRecentRepositories = vi.fn();
 const mockOpenRepository = vi.fn();
+const mockPinRepository = vi.fn();
+const mockUnpinRepository = vi.fn();
 
 const createMockState = () => ({
   recentRepositories: [] as RecentRepository[],
   loadRecentRepositories: mockLoadRecentRepositories,
   openRepository: mockOpenRepository,
+  pinRepository: mockPinRepository,
+  unpinRepository: mockUnpinRepository,
 });
 
 let mockState = createMockState();
@@ -41,6 +45,10 @@ vi.mock('@/lib/dateUtils', () => ({
   formatTimeAgo: (date: string) => `${date} ago`,
 }));
 
+vi.mock('@/lib/pathUtils', () => ({
+  truncatePath: (path: string) => path,
+}));
+
 vi.mock('./repository/CloneDialog', () => ({
   CloneDialog: ({ open }: { open: boolean }) =>
     open ? <div data-testid="clone-dialog">Clone Dialog</div> : null,
@@ -52,11 +60,70 @@ vi.mock('./repository/InitDialog', () => ({
 }));
 
 vi.mock('./repository/RecentRepoContextMenu', () => ({
-  RecentRepoContextMenu: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+  RecentRepoContextMenu: () => null,
 }));
+
+vi.mock('./repository/RepoCard', () => ({
+  RepoCard: ({ repo, onClick }: { repo: RecentRepository; onClick: (path: string) => void }) => (
+    <button
+      data-testid={`repo-card-${repo.name}`}
+      onClick={() => onClick(repo.path)}
+      disabled={!repo.exists}
+    >
+      <span>{repo.name}</span>
+      {repo.currentBranch && <span data-testid={`branch-${repo.name}`}>{repo.currentBranch}</span>}
+      {!repo.exists && <span data-testid={`missing-${repo.name}`}>missing</span>}
+      <span>{repo.displayPath}</span>
+    </button>
+  ),
+}));
+
+vi.mock('@/components/ui', async () => {
+  const actual = await vi.importActual<Record<string, unknown>>('@/components/ui');
+  return {
+    ...actual,
+    ContextMenuRoot: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+    ContextMenuTrigger: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+    ContextMenuPortal: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+    ContextMenuContent: ({ children }: { children: React.ReactNode }) => (
+      <div data-testid="context-menu-content">{children}</div>
+    ),
+    VirtualList: <T,>({
+      items,
+      children,
+      getItemKey,
+      emptyMessage,
+    }: {
+      items: T[];
+      children: (item: T, index: number) => React.ReactNode;
+      getItemKey: (item: T, index: number) => string | number;
+      emptyMessage?: string;
+    }) => (
+      <div data-testid="virtual-list">
+        {items.length === 0 && emptyMessage && <div>{emptyMessage}</div>}
+        {items.map((item, index) => (
+          <div key={getItemKey(item, index)}>{children(item, index)}</div>
+        ))}
+      </div>
+    ),
+  };
+});
 
 // Import after mocks
 import { WelcomeView } from './WelcomeView';
+
+function makeRepo(
+  overrides: Partial<RecentRepository> & { name: string; path: string }
+): RecentRepository {
+  return {
+    lastOpened: '2024-01-01',
+    exists: true,
+    currentBranch: 'main',
+    isPinned: false,
+    displayPath: overrides.path,
+    ...overrides,
+  };
+}
 
 describe('WelcomeView', () => {
   beforeEach(() => {
@@ -85,18 +152,20 @@ describe('WelcomeView', () => {
     expect(mockLoadRecentRepositories).toHaveBeenCalled();
   });
 
-  it('should not show recent repositories section when empty', () => {
+  it('should not show repository sections when empty', () => {
     mockState.recentRepositories = [];
 
     render(<WelcomeView />);
 
     expect(screen.queryByText('welcome.recentRepositories')).not.toBeInTheDocument();
+    expect(screen.queryByText('welcome.pinnedRepositories')).not.toBeInTheDocument();
+    expect(screen.getByText('welcome.noRecentRepositories')).toBeInTheDocument();
   });
 
   it('should show recent repositories when available', () => {
     mockState.recentRepositories = [
-      { name: 'project-one', path: '/path/to/project-one', lastOpened: '2024-01-01' },
-      { name: 'project-two', path: '/path/to/project-two', lastOpened: '2024-01-02' },
+      makeRepo({ name: 'project-one', path: '/path/to/project-one', lastOpened: '2024-01-01' }),
+      makeRepo({ name: 'project-two', path: '/path/to/project-two', lastOpened: '2024-01-02' }),
     ];
 
     render(<WelcomeView />);
@@ -107,21 +176,11 @@ describe('WelcomeView', () => {
   });
 
   it('should display repository paths', () => {
-    mockState.recentRepositories = [
-      { name: 'my-repo', path: '/Users/test/my-repo', lastOpened: '2024-01-01' },
-    ];
+    mockState.recentRepositories = [makeRepo({ name: 'my-repo', path: '~/Projects/my-repo' })];
 
     render(<WelcomeView />);
 
-    expect(screen.getByText('/Users/test/my-repo')).toBeInTheDocument();
-  });
-
-  it('should display formatted time ago', () => {
-    mockState.recentRepositories = [{ name: 'my-repo', path: '/path', lastOpened: '2024-01-01' }];
-
-    render(<WelcomeView />);
-
-    expect(screen.getByText('2024-01-01 ago')).toBeInTheDocument();
+    expect(screen.getByText('~/Projects/my-repo')).toBeInTheDocument();
   });
 
   it('should open init dialog when new repository clicked', async () => {
@@ -144,5 +203,209 @@ describe('WelcomeView', () => {
     await waitFor(() => {
       expect(screen.getByTestId('clone-dialog')).toBeInTheDocument();
     });
+  });
+
+  it('should show search input when repos exist', () => {
+    mockState.recentRepositories = [makeRepo({ name: 'my-repo', path: '/path/my-repo' })];
+
+    render(<WelcomeView />);
+
+    expect(screen.getByPlaceholderText('welcome.searchPlaceholder')).toBeInTheDocument();
+  });
+
+  it('should filter repos by name via search', () => {
+    mockState.recentRepositories = [
+      makeRepo({ name: 'alpha-project', path: '/path/alpha' }),
+      makeRepo({ name: 'beta-project', path: '/path/beta' }),
+    ];
+
+    render(<WelcomeView />);
+
+    const searchInput = screen.getByPlaceholderText('welcome.searchPlaceholder');
+    fireEvent.change(searchInput, { target: { value: 'alpha' } });
+
+    expect(screen.getByText('alpha-project')).toBeInTheDocument();
+    expect(screen.queryByText('beta-project')).not.toBeInTheDocument();
+  });
+
+  it('should filter repos by path via search', () => {
+    mockState.recentRepositories = [
+      makeRepo({ name: 'repo-a', path: '/home/user/work/repo-a', displayPath: '~/work/repo-a' }),
+      makeRepo({
+        name: 'repo-b',
+        path: '/home/user/personal/repo-b',
+        displayPath: '~/personal/repo-b',
+      }),
+    ];
+
+    render(<WelcomeView />);
+
+    const searchInput = screen.getByPlaceholderText('welcome.searchPlaceholder');
+    fireEvent.change(searchInput, { target: { value: 'personal' } });
+
+    expect(screen.queryByText('repo-a')).not.toBeInTheDocument();
+    expect(screen.getByText('repo-b')).toBeInTheDocument();
+  });
+
+  it('should filter repos by branch via search', () => {
+    mockState.recentRepositories = [
+      makeRepo({ name: 'repo-a', path: '/path/a', currentBranch: 'feature/login' }),
+      makeRepo({ name: 'repo-b', path: '/path/b', currentBranch: 'main' }),
+    ];
+
+    render(<WelcomeView />);
+
+    const searchInput = screen.getByPlaceholderText('welcome.searchPlaceholder');
+    fireEvent.change(searchInput, { target: { value: 'feature' } });
+
+    expect(screen.getByText('repo-a')).toBeInTheDocument();
+    expect(screen.queryByText('repo-b')).not.toBeInTheDocument();
+  });
+
+  it('should show no results message when search has no matches', () => {
+    mockState.recentRepositories = [makeRepo({ name: 'my-repo', path: '/path/my-repo' })];
+
+    render(<WelcomeView />);
+
+    const searchInput = screen.getByPlaceholderText('welcome.searchPlaceholder');
+    fireEvent.change(searchInput, { target: { value: 'nonexistent' } });
+
+    expect(screen.getByText('welcome.noResults')).toBeInTheDocument();
+  });
+
+  it('should show pinned section when pinned repos exist', () => {
+    mockState.recentRepositories = [
+      makeRepo({ name: 'pinned-repo', path: '/path/pinned', isPinned: true }),
+      makeRepo({ name: 'recent-repo', path: '/path/recent', isPinned: false }),
+    ];
+
+    render(<WelcomeView />);
+
+    expect(screen.getByText('welcome.pinnedRepositories')).toBeInTheDocument();
+    expect(screen.getByText('welcome.recentRepositories')).toBeInTheDocument();
+  });
+
+  it('should not show pinned section when no pinned repos', () => {
+    mockState.recentRepositories = [
+      makeRepo({ name: 'recent-repo', path: '/path/recent', isPinned: false }),
+    ];
+
+    render(<WelcomeView />);
+
+    expect(screen.queryByText('welcome.pinnedRepositories')).not.toBeInTheDocument();
+    expect(screen.getByText('welcome.recentRepositories')).toBeInTheDocument();
+  });
+
+  it('should separate pinned from recent repos', () => {
+    mockState.recentRepositories = [
+      makeRepo({ name: 'pinned-one', path: '/path/p1', isPinned: true }),
+      makeRepo({ name: 'recent-one', path: '/path/r1', isPinned: false }),
+    ];
+
+    render(<WelcomeView />);
+
+    expect(screen.getByTestId('repo-card-pinned-one')).toBeInTheDocument();
+    expect(screen.getByTestId('repo-card-recent-one')).toBeInTheDocument();
+  });
+
+  it('should search across both pinned and recent repos', () => {
+    mockState.recentRepositories = [
+      makeRepo({ name: 'pinned-alpha', path: '/path/pa', isPinned: true }),
+      makeRepo({ name: 'pinned-beta', path: '/path/pb', isPinned: true }),
+      makeRepo({ name: 'recent-alpha', path: '/path/ra', isPinned: false }),
+    ];
+
+    render(<WelcomeView />);
+
+    const searchInput = screen.getByPlaceholderText('welcome.searchPlaceholder');
+    fireEvent.change(searchInput, { target: { value: 'alpha' } });
+
+    expect(screen.getByText('pinned-alpha')).toBeInTheDocument();
+    expect(screen.queryByText('pinned-beta')).not.toBeInTheDocument();
+    expect(screen.getByText('recent-alpha')).toBeInTheDocument();
+  });
+
+  it('should hide pinned section when search filters out all pinned repos', () => {
+    mockState.recentRepositories = [
+      makeRepo({ name: 'pinned-repo', path: '/path/pinned', isPinned: true }),
+      makeRepo({ name: 'matching-recent', path: '/path/matching', isPinned: false }),
+    ];
+
+    render(<WelcomeView />);
+
+    const searchInput = screen.getByPlaceholderText('welcome.searchPlaceholder');
+    fireEvent.change(searchInput, { target: { value: 'matching' } });
+
+    expect(screen.queryByText('welcome.pinnedRepositories')).not.toBeInTheDocument();
+    expect(screen.getByText('matching-recent')).toBeInTheDocument();
+  });
+
+  it('should sort repos by name', () => {
+    mockState.recentRepositories = [
+      makeRepo({ name: 'charlie', path: '/path/c', lastOpened: '2024-01-03' }),
+      makeRepo({ name: 'alpha', path: '/path/a', lastOpened: '2024-01-01' }),
+      makeRepo({ name: 'bravo', path: '/path/b', lastOpened: '2024-01-02' }),
+    ];
+
+    render(<WelcomeView />);
+
+    // Change sort to name
+    const sortSelect = screen.getByRole('combobox');
+    fireEvent.click(sortSelect);
+    const nameOption = screen.getByText('common.name');
+    fireEvent.click(nameOption);
+
+    const cards = screen.getAllByTestId(/^repo-card-/);
+    expect(cards[0]).toHaveAttribute('data-testid', 'repo-card-alpha');
+    expect(cards[1]).toHaveAttribute('data-testid', 'repo-card-bravo');
+    expect(cards[2]).toHaveAttribute('data-testid', 'repo-card-charlie');
+  });
+
+  it('should sort repos by path', () => {
+    mockState.recentRepositories = [
+      makeRepo({ name: 'repo-c', path: '/z/path', displayPath: '~/z/path' }),
+      makeRepo({ name: 'repo-a', path: '/a/path', displayPath: '~/a/path' }),
+    ];
+
+    render(<WelcomeView />);
+
+    const sortSelect = screen.getByRole('combobox');
+    fireEvent.click(sortSelect);
+    const pathOption = screen.getByText('common.path');
+    fireEvent.click(pathOption);
+
+    const cards = screen.getAllByTestId(/^repo-card-/);
+    expect(cards[0]).toHaveAttribute('data-testid', 'repo-card-repo-a');
+    expect(cards[1]).toHaveAttribute('data-testid', 'repo-card-repo-c');
+  });
+
+  it('should show missing repos as disabled', () => {
+    mockState.recentRepositories = [
+      makeRepo({ name: 'missing-repo', path: '/path/gone', exists: false, currentBranch: null }),
+    ];
+
+    render(<WelcomeView />);
+
+    const card = screen.getByTestId('repo-card-missing-repo');
+    expect(card).toBeDisabled();
+    expect(screen.getByTestId('missing-missing-repo')).toBeInTheDocument();
+  });
+
+  it('should show branch badge for existing repos', () => {
+    mockState.recentRepositories = [
+      makeRepo({ name: 'my-repo', path: '/path/repo', currentBranch: 'develop' }),
+    ];
+
+    render(<WelcomeView />);
+
+    expect(screen.getByTestId('branch-my-repo')).toHaveTextContent('develop');
+  });
+
+  it('should use VirtualList for recent repos', () => {
+    mockState.recentRepositories = [makeRepo({ name: 'repo-1', path: '/path/1', isPinned: false })];
+
+    render(<WelcomeView />);
+
+    expect(screen.getByTestId('virtual-list')).toBeInTheDocument();
   });
 });

--- a/src/components/WelcomeView.tsx
+++ b/src/components/WelcomeView.tsx
@@ -1,12 +1,25 @@
-import { useEffect, useState } from 'react';
+import { useCallback, useEffect, useMemo, useState } from 'react';
 import { useTranslation } from 'react-i18next';
-import { FolderOpen, FolderPlus, GitBranchPlus, Clock } from 'lucide-react';
+import { FolderOpen, FolderPlus, GitBranchPlus, Clock, Search, Pin } from 'lucide-react';
 import { open } from '@tauri-apps/plugin-dialog';
-import { useRepositoryStore } from '../store/repositoryStore';
-import { formatTimeAgo } from '@/lib/dateUtils';
+import type { RecentRepository } from '@/types';
+import { useRepositoryStore } from '@/store/repositoryStore';
+import {
+  Input,
+  Select,
+  SelectItem,
+  VirtualList,
+  ContextMenuRoot,
+  ContextMenuTrigger,
+  ContextMenuPortal,
+  ContextMenuContent,
+} from '@/components/ui';
 import { CloneDialog } from './repository/CloneDialog';
 import { InitDialog } from './repository/InitDialog';
 import { RecentRepoContextMenu } from './repository/RecentRepoContextMenu';
+import { RepoCard } from './repository/RepoCard';
+
+type SortBy = 'lastOpened' | 'name' | 'path';
 
 // Get the tab-aware open function from window
 const openInTab = (path: string) => {
@@ -19,15 +32,65 @@ const openInTab = (path: string) => {
   return useRepositoryStore.getState().openRepository(path);
 };
 
+function matchesSearch(repo: RecentRepository, query: string): boolean {
+  const lower = query.toLowerCase();
+  return (
+    repo.name.toLowerCase().includes(lower) ||
+    repo.displayPath.toLowerCase().includes(lower) ||
+    (repo.currentBranch?.toLowerCase().includes(lower) ?? false)
+  );
+}
+
+function sortRepos(repos: RecentRepository[], sortBy: SortBy): RecentRepository[] {
+  return [...repos].sort((a, b) => {
+    switch (sortBy) {
+      case 'name':
+        return a.name.localeCompare(b.name);
+      case 'path':
+        return a.displayPath.localeCompare(b.displayPath);
+      case 'lastOpened':
+      default:
+        return new Date(b.lastOpened).getTime() - new Date(a.lastOpened).getTime();
+    }
+  });
+}
+
 export function WelcomeView() {
   const { t } = useTranslation();
   const { recentRepositories, loadRecentRepositories } = useRepositoryStore();
   const [showCloneDialog, setShowCloneDialog] = useState(false);
   const [showInitDialog, setShowInitDialog] = useState(false);
+  const [searchQuery, setSearchQuery] = useState('');
+  const [sortBy, setSortBy] = useState<SortBy>('lastOpened');
+  const [contextMenuRepo, setContextMenuRepo] = useState<RecentRepository | null>(null);
 
   useEffect(() => {
     loadRecentRepositories();
   }, [loadRecentRepositories]);
+
+  const filtered = useMemo(() => {
+    const query = searchQuery.trim();
+    if (!query) return recentRepositories;
+    return recentRepositories.filter((repo) => matchesSearch(repo, query));
+  }, [recentRepositories, searchQuery]);
+
+  const pinnedRepos = useMemo(
+    () =>
+      sortRepos(
+        filtered.filter((r) => r.isPinned),
+        sortBy
+      ),
+    [filtered, sortBy]
+  );
+
+  const recentRepos = useMemo(
+    () =>
+      sortRepos(
+        filtered.filter((r) => !r.isPinned),
+        sortBy
+      ),
+    [filtered, sortBy]
+  );
 
   const handleOpenRepository = async () => {
     const selected = await open({
@@ -41,17 +104,21 @@ export function WelcomeView() {
     }
   };
 
-  const handleOpenRecent = async (path: string) => {
-    await openInTab(path);
+  const handleOpenRecent = (path: string) => {
+    openInTab(path);
   };
 
+  const handleRepoContextMenu = useCallback((repo: RecentRepository) => {
+    setContextMenuRepo(repo);
+  }, []);
+
   return (
-    <div className="flex items-center justify-center h-full p-12">
-      <div className="text-center max-w-150">
+    <div className="flex flex-col items-center h-full p-12 overflow-hidden">
+      <div className="text-center w-full max-w-150">
         <h1 className="text-5xl font-bold m-0 mb-2 text-(--text-primary)">{t('welcome.title')}</h1>
         <p className="text-lg text-(--text-secondary) m-0 mb-8">{t('welcome.subtitle')}</p>
 
-        <div className="flex justify-center gap-4 mb-12">
+        <div className="flex justify-center gap-4 mb-8">
           <button
             className="flex flex-col items-center gap-3 py-6 px-8 bg-(--bg-card) border border-(--border-color) rounded-lg text-(--text-primary) cursor-pointer transition-all min-w-40 hover:not-disabled:bg-(--bg-hover) hover:not-disabled:border-(--accent-color) disabled:opacity-50 disabled:cursor-not-allowed"
             onClick={() => setShowInitDialog(true)}
@@ -77,38 +144,89 @@ export function WelcomeView() {
 
         <InitDialog open={showInitDialog} onOpenChange={setShowInitDialog} />
         <CloneDialog open={showCloneDialog} onOpenChange={setShowCloneDialog} />
-
-        {recentRepositories.length > 0 && (
-          <div className="text-left">
-            <h2 className="flex items-center gap-2 text-sm font-semibold text-(--text-secondary) m-0 mb-4 uppercase tracking-wide">
-              <Clock size={16} />
-              {t('welcome.recentRepositories')}
-            </h2>
-            <ul className="list-none p-0 m-0">
-              {recentRepositories.map((repo) => (
-                <li key={repo.path}>
-                  <RecentRepoContextMenu repo={repo} onOpenInTab={handleOpenRecent}>
-                    <button
-                      className="flex flex-col items-start w-full py-3 px-4 bg-transparent border border-(--border-color) rounded-md mb-2 cursor-pointer transition-all text-left hover:bg-(--bg-hover) hover:border-(--accent-color)"
-                      onClick={() => handleOpenRecent(repo.path)}
-                    >
-                      <span className="text-sm font-semibold text-(--text-primary)">
-                        {repo.name}
-                      </span>
-                      <span className="text-xs text-(--text-secondary) mt-1 break-all">
-                        {repo.path}
-                      </span>
-                      <span className="text-sm text-(--text-tertiary) mt-1">
-                        {formatTimeAgo(repo.lastOpened)}
-                      </span>
-                    </button>
-                  </RecentRepoContextMenu>
-                </li>
-              ))}
-            </ul>
-          </div>
-        )}
       </div>
+
+      {recentRepositories.length > 0 && (
+        <div className="flex flex-col flex-1 w-full max-w-150 min-h-0 text-left">
+          <div className="flex items-center gap-3 mb-4">
+            <div className="welcome-search flex-1">
+              <Search size={14} className="welcome-search-icon" />
+              <Input
+                placeholder={t('welcome.searchPlaceholder')}
+                value={searchQuery}
+                onChange={(e) => setSearchQuery(e.target.value)}
+              />
+            </div>
+            <Select
+              value={sortBy}
+              onValueChange={(v) => setSortBy(v as SortBy)}
+              placeholder={t('staging.filters.labels.sortBy')}
+              className="w-40"
+            >
+              <SelectItem value="lastOpened">{t('welcome.sortLastOpened')}</SelectItem>
+              <SelectItem value="name">{t('common.name')}</SelectItem>
+              <SelectItem value="path">{t('common.path')}</SelectItem>
+            </Select>
+          </div>
+
+          <ContextMenuRoot>
+            <ContextMenuTrigger asChild>
+              <div className="flex flex-col flex-1 min-h-0">
+                {pinnedRepos.length > 0 && (
+                  <div className="mb-4">
+                    <h2 className="welcome-section-header">
+                      <Pin size={14} />
+                      {t('welcome.pinnedRepositories')}
+                    </h2>
+                    {pinnedRepos.map((repo) => (
+                      <RepoCard
+                        key={repo.path}
+                        repo={repo}
+                        onClick={handleOpenRecent}
+                        onContextMenu={() => handleRepoContextMenu(repo)}
+                      />
+                    ))}
+                  </div>
+                )}
+
+                <div className="flex flex-col flex-1 min-h-0">
+                  <h2 className="welcome-section-header">
+                    <Clock size={14} />
+                    {t('welcome.recentRepositories')}
+                  </h2>
+                  <VirtualList
+                    items={recentRepos}
+                    getItemKey={(repo) => repo.path}
+                    itemHeight={56}
+                    overscan={5}
+                    emptyMessage={t('welcome.noResults')}
+                    className="welcome-repo-list"
+                  >
+                    {(repo) => (
+                      <RepoCard
+                        repo={repo}
+                        onClick={handleOpenRecent}
+                        onContextMenu={() => handleRepoContextMenu(repo)}
+                      />
+                    )}
+                  </VirtualList>
+                </div>
+              </div>
+            </ContextMenuTrigger>
+            <ContextMenuPortal>
+              <ContextMenuContent className="menu-content">
+                {contextMenuRepo && (
+                  <RecentRepoContextMenu repo={contextMenuRepo} onOpenInTab={handleOpenRecent} />
+                )}
+              </ContextMenuContent>
+            </ContextMenuPortal>
+          </ContextMenuRoot>
+        </div>
+      )}
+
+      {recentRepositories.length === 0 && (
+        <p className="text-sm text-(--text-muted)">{t('welcome.noRecentRepositories')}</p>
+      )}
     </div>
   );
 }

--- a/src/components/repository/RecentRepoContextMenu.test.tsx
+++ b/src/components/repository/RecentRepoContextMenu.test.tsx
@@ -1,0 +1,267 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import type { RecentRepository } from '@/types';
+
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({
+    t: (key: string) => key,
+  }),
+}));
+
+vi.mock('@tauri-apps/api/webviewWindow', () => ({
+  // eslint-disable-next-line @typescript-eslint/naming-convention
+  WebviewWindow: vi.fn().mockImplementation(() => ({
+    once: vi.fn(),
+  })),
+}));
+
+const mockPinRepository = vi.fn();
+const mockUnpinRepository = vi.fn();
+const mockLoadRecentRepositories = vi.fn();
+
+vi.mock('@/store/repositoryStore', () => ({
+  useRepositoryStore: () => ({
+    loadRecentRepositories: mockLoadRecentRepositories,
+    pinRepository: mockPinRepository,
+    unpinRepository: mockUnpinRepository,
+  }),
+}));
+
+vi.mock('@/services/api', () => ({
+  repositoryApi: {
+    removeRecentRepository: vi.fn().mockResolvedValue(undefined),
+  },
+  shellApi: {
+    showInFolder: vi.fn().mockResolvedValue(undefined),
+  },
+}));
+
+vi.mock('@/hooks', () => ({
+  toast: {
+    error: vi.fn(),
+    success: vi.fn(),
+  },
+}));
+
+vi.mock('@/lib/errorUtils', () => ({
+  getErrorMessage: (err: unknown) => String(err),
+}));
+
+// Mock ContextMenu to render items directly for testing
+vi.mock('@/components/ui', async () => {
+  const actual = await vi.importActual<Record<string, unknown>>('@/components/ui');
+  return {
+    ...actual,
+    ContextMenu: ({
+      children,
+      trigger,
+    }: {
+      children: React.ReactNode;
+      trigger: React.ReactNode;
+    }) => (
+      <div>
+        <div data-testid="context-trigger">{trigger}</div>
+        <div data-testid="context-menu">{children}</div>
+      </div>
+    ),
+    MenuItem: ({
+      children,
+      onSelect,
+      disabled,
+      danger,
+    }: {
+      children: React.ReactNode;
+      onSelect?: () => void;
+      disabled?: boolean;
+      danger?: boolean;
+    }) => (
+      <button
+        onClick={onSelect}
+        disabled={disabled}
+        data-danger={danger || undefined}
+        data-testid={`menu-item-${String(children)}`}
+      >
+        {children}
+      </button>
+    ),
+    MenuSeparator: () => <hr />,
+  };
+});
+
+import { RecentRepoContextMenu } from './RecentRepoContextMenu';
+
+function makeRepo(overrides: Partial<RecentRepository> = {}): RecentRepository {
+  return {
+    name: 'test-repo',
+    path: '/home/user/test-repo',
+    lastOpened: '2024-06-15',
+    exists: true,
+    currentBranch: 'main',
+    isPinned: false,
+    displayPath: '~/test-repo',
+    ...overrides,
+  };
+}
+
+describe('RecentRepoContextMenu', () => {
+  const mockOnOpenInTab = vi.fn();
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('should render trigger children', () => {
+    render(
+      <RecentRepoContextMenu repo={makeRepo()} onOpenInTab={mockOnOpenInTab}>
+        <div data-testid="trigger">Trigger</div>
+      </RecentRepoContextMenu>
+    );
+
+    expect(screen.getByTestId('trigger')).toBeInTheDocument();
+  });
+
+  it('should render open menu item', () => {
+    render(
+      <RecentRepoContextMenu repo={makeRepo()} onOpenInTab={mockOnOpenInTab}>
+        <div>Trigger</div>
+      </RecentRepoContextMenu>
+    );
+
+    expect(screen.getByTestId('menu-item-repository.contextMenu.open')).toBeInTheDocument();
+  });
+
+  it('should render open in new window menu item', () => {
+    render(
+      <RecentRepoContextMenu repo={makeRepo()} onOpenInTab={mockOnOpenInTab}>
+        <div>Trigger</div>
+      </RecentRepoContextMenu>
+    );
+
+    expect(
+      screen.getByTestId('menu-item-repository.contextMenu.openInNewWindow')
+    ).toBeInTheDocument();
+  });
+
+  it('should render show in finder menu item', () => {
+    render(
+      <RecentRepoContextMenu repo={makeRepo()} onOpenInTab={mockOnOpenInTab}>
+        <div>Trigger</div>
+      </RecentRepoContextMenu>
+    );
+
+    expect(screen.getByTestId('menu-item-repository.contextMenu.showInFinder')).toBeInTheDocument();
+  });
+
+  it('should render pin menu item for unpinned repo', () => {
+    render(
+      <RecentRepoContextMenu repo={makeRepo({ isPinned: false })} onOpenInTab={mockOnOpenInTab}>
+        <div>Trigger</div>
+      </RecentRepoContextMenu>
+    );
+
+    expect(screen.getByTestId('menu-item-welcome.pin')).toBeInTheDocument();
+  });
+
+  it('should render unpin menu item for pinned repo', () => {
+    render(
+      <RecentRepoContextMenu repo={makeRepo({ isPinned: true })} onOpenInTab={mockOnOpenInTab}>
+        <div>Trigger</div>
+      </RecentRepoContextMenu>
+    );
+
+    expect(screen.getByTestId('menu-item-welcome.unpin')).toBeInTheDocument();
+  });
+
+  it('should render remove from recent menu item', () => {
+    render(
+      <RecentRepoContextMenu repo={makeRepo()} onOpenInTab={mockOnOpenInTab}>
+        <div>Trigger</div>
+      </RecentRepoContextMenu>
+    );
+
+    expect(
+      screen.getByTestId('menu-item-repository.contextMenu.removeFromRecent')
+    ).toBeInTheDocument();
+  });
+
+  it('should disable open when repo does not exist', () => {
+    render(
+      <RecentRepoContextMenu repo={makeRepo({ exists: false })} onOpenInTab={mockOnOpenInTab}>
+        <div>Trigger</div>
+      </RecentRepoContextMenu>
+    );
+
+    expect(screen.getByTestId('menu-item-repository.contextMenu.open')).toBeDisabled();
+  });
+
+  it('should disable open in new window when repo does not exist', () => {
+    render(
+      <RecentRepoContextMenu repo={makeRepo({ exists: false })} onOpenInTab={mockOnOpenInTab}>
+        <div>Trigger</div>
+      </RecentRepoContextMenu>
+    );
+
+    expect(screen.getByTestId('menu-item-repository.contextMenu.openInNewWindow')).toBeDisabled();
+  });
+
+  it('should disable show in finder when repo does not exist', () => {
+    render(
+      <RecentRepoContextMenu repo={makeRepo({ exists: false })} onOpenInTab={mockOnOpenInTab}>
+        <div>Trigger</div>
+      </RecentRepoContextMenu>
+    );
+
+    expect(screen.getByTestId('menu-item-repository.contextMenu.showInFinder')).toBeDisabled();
+  });
+
+  it('should enable open when repo exists', () => {
+    render(
+      <RecentRepoContextMenu repo={makeRepo({ exists: true })} onOpenInTab={mockOnOpenInTab}>
+        <div>Trigger</div>
+      </RecentRepoContextMenu>
+    );
+
+    expect(screen.getByTestId('menu-item-repository.contextMenu.open')).toBeEnabled();
+  });
+
+  it('should enable open in new window when repo exists', () => {
+    render(
+      <RecentRepoContextMenu repo={makeRepo({ exists: true })} onOpenInTab={mockOnOpenInTab}>
+        <div>Trigger</div>
+      </RecentRepoContextMenu>
+    );
+
+    expect(screen.getByTestId('menu-item-repository.contextMenu.openInNewWindow')).toBeEnabled();
+  });
+
+  it('should mark remove as danger', () => {
+    render(
+      <RecentRepoContextMenu repo={makeRepo()} onOpenInTab={mockOnOpenInTab}>
+        <div>Trigger</div>
+      </RecentRepoContextMenu>
+    );
+
+    const removeItem = screen.getByTestId('menu-item-repository.contextMenu.removeFromRecent');
+    expect(removeItem).toHaveAttribute('data-danger', 'true');
+  });
+
+  it('should not disable pin/unpin when repo does not exist', () => {
+    render(
+      <RecentRepoContextMenu repo={makeRepo({ exists: false })} onOpenInTab={mockOnOpenInTab}>
+        <div>Trigger</div>
+      </RecentRepoContextMenu>
+    );
+
+    expect(screen.getByTestId('menu-item-welcome.pin')).toBeEnabled();
+  });
+
+  it('should not disable remove when repo does not exist', () => {
+    render(
+      <RecentRepoContextMenu repo={makeRepo({ exists: false })} onOpenInTab={mockOnOpenInTab}>
+        <div>Trigger</div>
+      </RecentRepoContextMenu>
+    );
+
+    expect(screen.getByTestId('menu-item-repository.contextMenu.removeFromRecent')).toBeEnabled();
+  });
+});

--- a/src/components/repository/RecentRepoContextMenu.tsx
+++ b/src/components/repository/RecentRepoContextMenu.tsx
@@ -1,9 +1,9 @@
-import { ReactNode } from 'react';
+import { type ReactNode } from 'react';
 import { useTranslation } from 'react-i18next';
-import { FolderOpen, ExternalLink, Trash2 } from 'lucide-react';
+import { FolderOpen, ExternalLink, Trash2, Pin, PinOff, FolderSearch } from 'lucide-react';
 import { WebviewWindow } from '@tauri-apps/api/webviewWindow';
 import type { RecentRepository } from '@/types';
-import { repositoryApi } from '@/services/api';
+import { repositoryApi, shellApi } from '@/services/api';
 import { useRepositoryStore } from '@/store/repositoryStore';
 import { ContextMenu, MenuItem, MenuSeparator } from '@/components/ui';
 import { toast } from '@/hooks';
@@ -11,13 +11,14 @@ import { getErrorMessage } from '@/lib/errorUtils';
 
 interface RecentRepoContextMenuProps {
   repo: RecentRepository;
-  children: ReactNode;
+  /** When provided, wraps children with ContextMenu. When omitted, renders just menu items. */
+  children?: ReactNode;
   onOpenInTab: (path: string) => void;
 }
 
 export function RecentRepoContextMenu({ repo, children, onOpenInTab }: RecentRepoContextMenuProps) {
   const { t } = useTranslation();
-  const { loadRecentRepositories } = useRepositoryStore();
+  const { loadRecentRepositories, pinRepository, unpinRepository } = useRepositoryStore();
 
   const handleOpenInTab = () => {
     onOpenInTab(repo.path);
@@ -36,6 +37,22 @@ export function RecentRepoContextMenu({ repo, children, onOpenInTab }: RecentRep
     });
   };
 
+  const handleShowInFinder = async () => {
+    try {
+      await shellApi.showInFolder(repo.path);
+    } catch (err) {
+      toast.error(t('notifications.error.showInFinderFailed'), getErrorMessage(err));
+    }
+  };
+
+  const handleTogglePin = async () => {
+    if (repo.isPinned) {
+      await unpinRepository(repo.path);
+    } else {
+      await pinRepository(repo.path);
+    }
+  };
+
   const handleRemove = async () => {
     try {
       await repositoryApi.removeRecentRepository(repo.path);
@@ -45,18 +62,31 @@ export function RecentRepoContextMenu({ repo, children, onOpenInTab }: RecentRep
     }
   };
 
-  return (
-    <ContextMenu trigger={children}>
-      <MenuItem icon={FolderOpen} onSelect={handleOpenInTab}>
+  const menuItems = (
+    <>
+      <MenuItem icon={FolderOpen} onSelect={handleOpenInTab} disabled={!repo.exists}>
         {t('repository.contextMenu.open')}
       </MenuItem>
-      <MenuItem icon={ExternalLink} onSelect={handleOpenInNewWindow}>
+      <MenuItem icon={ExternalLink} onSelect={handleOpenInNewWindow} disabled={!repo.exists}>
         {t('repository.contextMenu.openInNewWindow')}
+      </MenuItem>
+      <MenuItem icon={FolderSearch} onSelect={handleShowInFinder} disabled={!repo.exists}>
+        {t('repository.contextMenu.showInFinder')}
+      </MenuItem>
+      <MenuSeparator />
+      <MenuItem icon={repo.isPinned ? PinOff : Pin} onSelect={handleTogglePin}>
+        {repo.isPinned ? t('welcome.unpin') : t('welcome.pin')}
       </MenuItem>
       <MenuSeparator />
       <MenuItem icon={Trash2} danger onSelect={handleRemove}>
         {t('repository.contextMenu.removeFromRecent')}
       </MenuItem>
-    </ContextMenu>
+    </>
   );
+
+  if (children) {
+    return <ContextMenu trigger={children}>{menuItems}</ContextMenu>;
+  }
+
+  return menuItems;
 }

--- a/src/components/repository/RepoCard.test.tsx
+++ b/src/components/repository/RepoCard.test.tsx
@@ -1,0 +1,155 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import type { RecentRepository } from '@/types';
+
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({
+    t: (key: string) => key,
+  }),
+}));
+
+vi.mock('@/lib/dateUtils', () => ({
+  formatTimeAgo: (date: string) => `${date} ago`,
+}));
+
+vi.mock('@/lib/pathUtils', () => ({
+  truncatePath: (path: string, _maxLen: number) => path,
+}));
+
+vi.mock('@/components/ui', async () => {
+  const actual = await vi.importActual<Record<string, unknown>>('@/components/ui');
+  return {
+    ...actual,
+    Badge: ({ children, variant }: { children: React.ReactNode; variant?: string }) => (
+      <span data-testid={`badge-${variant ?? 'default'}`}>{children}</span>
+    ),
+  };
+});
+
+import { RepoCard } from './RepoCard';
+
+function makeRepo(overrides: Partial<RecentRepository> = {}): RecentRepository {
+  return {
+    name: 'test-repo',
+    path: '/home/user/test-repo',
+    lastOpened: '2024-06-15',
+    exists: true,
+    currentBranch: 'main',
+    isPinned: false,
+    displayPath: '~/test-repo',
+    ...overrides,
+  };
+}
+
+describe('RepoCard', () => {
+  const mockOnClick = vi.fn();
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('should render repo name', () => {
+    render(<RepoCard repo={makeRepo()} onClick={mockOnClick} />);
+
+    expect(screen.getByText('test-repo')).toBeInTheDocument();
+  });
+
+  it('should render display path', () => {
+    render(
+      <RepoCard repo={makeRepo({ displayPath: '~/Projects/my-repo' })} onClick={mockOnClick} />
+    );
+
+    expect(screen.getByText('~/Projects/my-repo')).toBeInTheDocument();
+  });
+
+  it('should render time ago', () => {
+    render(<RepoCard repo={makeRepo({ lastOpened: '2024-06-15' })} onClick={mockOnClick} />);
+
+    expect(screen.getByText('2024-06-15 ago')).toBeInTheDocument();
+  });
+
+  it('should render branch badge for existing repo', () => {
+    render(<RepoCard repo={makeRepo({ currentBranch: 'develop' })} onClick={mockOnClick} />);
+
+    const badge = screen.getByTestId('badge-accent');
+    expect(badge).toHaveTextContent('develop');
+  });
+
+  it('should not render branch badge when no branch', () => {
+    render(<RepoCard repo={makeRepo({ currentBranch: null })} onClick={mockOnClick} />);
+
+    expect(screen.queryByTestId('badge-accent')).not.toBeInTheDocument();
+  });
+
+  it('should render missing badge when repo does not exist', () => {
+    render(
+      <RepoCard repo={makeRepo({ exists: false, currentBranch: null })} onClick={mockOnClick} />
+    );
+
+    const badge = screen.getByTestId('badge-error');
+    expect(badge).toHaveTextContent('submodules.status.missing');
+  });
+
+  it('should not render missing badge when repo exists', () => {
+    render(<RepoCard repo={makeRepo({ exists: true })} onClick={mockOnClick} />);
+
+    expect(screen.queryByTestId('badge-error')).not.toBeInTheDocument();
+  });
+
+  it('should be disabled when repo does not exist', () => {
+    render(<RepoCard repo={makeRepo({ exists: false })} onClick={mockOnClick} />);
+
+    const button = screen.getByRole('button');
+    expect(button).toBeDisabled();
+  });
+
+  it('should be enabled when repo exists', () => {
+    render(<RepoCard repo={makeRepo({ exists: true })} onClick={mockOnClick} />);
+
+    const button = screen.getByRole('button');
+    expect(button).toBeEnabled();
+  });
+
+  it('should call onClick with repo path when clicked', () => {
+    render(<RepoCard repo={makeRepo({ path: '/my/path' })} onClick={mockOnClick} />);
+
+    fireEvent.click(screen.getByRole('button'));
+
+    expect(mockOnClick).toHaveBeenCalledWith('/my/path');
+  });
+
+  it('should show GitBranch icon for existing repo', () => {
+    const { container } = render(<RepoCard repo={makeRepo()} onClick={mockOnClick} />);
+
+    const iconDiv = container.querySelector('.welcome-repo-card-icon');
+    expect(iconDiv).not.toHaveClass('welcome-repo-card-icon--missing');
+  });
+
+  it('should show AlertTriangle icon with warning style for missing repo', () => {
+    const { container } = render(
+      <RepoCard repo={makeRepo({ exists: false })} onClick={mockOnClick} />
+    );
+
+    const iconDiv = container.querySelector('.welcome-repo-card-icon');
+    expect(iconDiv).toHaveClass('welcome-repo-card-icon--missing');
+  });
+
+  it('should not render branch badge for missing repo even if branch data exists', () => {
+    render(
+      <RepoCard repo={makeRepo({ exists: false, currentBranch: 'main' })} onClick={mockOnClick} />
+    );
+
+    // Should show error badge (missing), not accent badge (branch)
+    expect(screen.getByTestId('badge-error')).toBeInTheDocument();
+    expect(screen.queryByTestId('badge-accent')).not.toBeInTheDocument();
+  });
+
+  it('should set title attribute on path for tooltip', () => {
+    render(
+      <RepoCard repo={makeRepo({ displayPath: '~/very/long/path/repo' })} onClick={mockOnClick} />
+    );
+
+    const pathElement = screen.getByText('~/very/long/path/repo');
+    expect(pathElement).toHaveAttribute('title', '~/very/long/path/repo');
+  });
+});

--- a/src/components/repository/RepoCard.tsx
+++ b/src/components/repository/RepoCard.tsx
@@ -1,0 +1,50 @@
+import { useTranslation } from 'react-i18next';
+import { GitBranch, AlertTriangle } from 'lucide-react';
+import type { RecentRepository } from '@/types';
+import { Badge } from '@/components/ui';
+import { cn } from '@/lib/utils';
+import { formatTimeAgo } from '@/lib/dateUtils';
+import { truncatePath } from '@/lib/pathUtils';
+
+interface RepoCardProps extends Omit<React.ButtonHTMLAttributes<HTMLButtonElement>, 'onClick'> {
+  repo: RecentRepository;
+  onClick: (path: string) => void;
+}
+
+export function RepoCard({ repo, onClick, className, ...rest }: RepoCardProps) {
+  const { t } = useTranslation();
+
+  return (
+    <button
+      className={cn('welcome-repo-card', className)}
+      disabled={!repo.exists}
+      onClick={() => onClick(repo.path)}
+      {...rest}
+    >
+      <div
+        className={`welcome-repo-card-icon${!repo.exists ? ' welcome-repo-card-icon--missing' : ''}`}
+      >
+        {repo.exists ? <GitBranch size={16} /> : <AlertTriangle size={16} />}
+      </div>
+      <div className="welcome-repo-card-content">
+        <div className="welcome-repo-card-header">
+          <span className="welcome-repo-card-name">{repo.name}</span>
+          {repo.exists && repo.currentBranch && (
+            <Badge variant="accent" size="sm">
+              {repo.currentBranch}
+            </Badge>
+          )}
+          {!repo.exists && (
+            <Badge variant="error" size="sm">
+              {t('submodules.status.missing')}
+            </Badge>
+          )}
+        </div>
+        <span className="welcome-repo-card-path" title={repo.displayPath}>
+          {truncatePath(repo.displayPath, 60)}
+        </span>
+      </div>
+      <span className="welcome-repo-card-time">{formatTimeAgo(repo.lastOpened)}</span>
+    </button>
+  );
+}

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -385,7 +385,13 @@
     "cloneRepository": "Clone Repository",
     "recentRepositories": "Recent Repositories",
     "noRecentRepositories": "No recent repositories",
-    "selectRepository": "Select Repository"
+    "selectRepository": "Select Repository",
+    "searchPlaceholder": "Search repositories...",
+    "pinnedRepositories": "Pinned",
+    "noResults": "No matching repositories",
+    "pin": "Pin",
+    "unpin": "Unpin",
+    "sortLastOpened": "Last Opened"
   },
   "branches": {
     "validation": {
@@ -1806,6 +1812,7 @@
     "contextMenu": {
       "open": "Open",
       "openInNewWindow": "Open in New Window",
+      "showInFinder": "Show in Finder",
       "removeFromRecent": "Remove from Recent",
       "openWindowFailed": "Open window failed",
       "removeFailed": "Remove repository failed"

--- a/src/index.css
+++ b/src/index.css
@@ -1362,6 +1362,120 @@ code {
   }
 }
 
+/* ==================== Welcome Screen ==================== */
+
+.welcome-repo-card {
+  display: flex;
+  flex-direction: row;
+  align-items: center;
+  gap: 0.75rem;
+  width: 100%;
+  padding: 0.625rem 0.75rem;
+  background: transparent;
+  border: none;
+  border-radius: var(--radius-md);
+  cursor: pointer;
+  transition: all 0.15s ease;
+  text-align: left;
+}
+
+.welcome-repo-card:hover:not(:disabled) {
+  background: var(--bg-hover);
+}
+
+.welcome-repo-card:disabled {
+  opacity: 0.6;
+  cursor: not-allowed;
+}
+
+.welcome-repo-card-icon {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  flex-shrink: 0;
+  width: 2rem;
+  height: 2rem;
+  border-radius: var(--radius-sm);
+  background: var(--bg-secondary);
+  color: var(--text-secondary);
+}
+
+.welcome-repo-card-icon--missing {
+  color: var(--color-warning);
+  background: var(--color-warning-bg, rgba(234, 179, 8, 0.1));
+}
+
+.welcome-repo-card-content {
+  display: flex;
+  flex-direction: column;
+  flex: 1;
+  min-width: 0;
+  gap: 0.125rem;
+}
+
+.welcome-repo-card-header {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+}
+
+.welcome-repo-card-name {
+  font-size: 0.8125rem;
+  font-weight: 600;
+  color: var(--text-primary);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.welcome-repo-card-path {
+  font-size: 0.6875rem;
+  color: var(--text-secondary);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.welcome-repo-card-time {
+  flex-shrink: 0;
+  font-size: 0.6875rem;
+  color: var(--text-tertiary);
+}
+
+.welcome-search {
+  position: relative;
+  display: flex;
+  align-items: center;
+}
+
+.welcome-search-icon {
+  position: absolute;
+  left: 0.625rem;
+  color: var(--text-muted);
+  pointer-events: none;
+}
+
+.welcome-search .input {
+  padding-left: 2rem;
+}
+
+.welcome-repo-list {
+  flex: 1;
+  min-height: 0;
+}
+
+.welcome-section-header {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  font-size: 0.6875rem;
+  font-weight: 600;
+  color: var(--text-secondary);
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  margin-bottom: 0.5rem;
+}
+
 /* ==================== Interactive Rebase ==================== */
 
 .interactive-rebase-list {

--- a/src/lib/pathUtils.test.ts
+++ b/src/lib/pathUtils.test.ts
@@ -1,0 +1,54 @@
+import { describe, it, expect } from 'vitest';
+import { truncatePath } from './pathUtils';
+
+describe('truncatePath', () => {
+  it('should return path unchanged when shorter than maxLen', () => {
+    expect(truncatePath('~/Projects/foo', 50)).toBe('~/Projects/foo');
+  });
+
+  it('should return path unchanged when equal to maxLen', () => {
+    const path = '~/Projects/foo';
+    expect(truncatePath(path, path.length)).toBe(path);
+  });
+
+  it('should truncate long unix paths with ... in the middle', () => {
+    const path = '~/Projects/very/deep/nested/structure/repo';
+    const result = truncatePath(path, 30);
+    expect(result).toContain('...');
+    expect(result.length).toBeLessThanOrEqual(35); // allows some slack
+    expect(result.startsWith('~')).toBe(true);
+    expect(result.endsWith('repo')).toBe(true);
+  });
+
+  it('should truncate long windows paths with backslash separator', () => {
+    const path = 'C:\\Users\\user\\Documents\\Projects\\deep\\repo';
+    const result = truncatePath(path, 25);
+    expect(result).toContain('...');
+    expect(result.includes('\\')).toBe(true);
+    expect(result.endsWith('repo')).toBe(true);
+  });
+
+  it('should handle paths with only two segments', () => {
+    const path = '~/repo';
+    expect(truncatePath(path, 3)).toBe('~/repo');
+  });
+
+  it('should handle root-level paths', () => {
+    const path = '/repo';
+    expect(truncatePath(path, 3)).toBe('/repo');
+  });
+
+  it('should keep first and last parts when truncating', () => {
+    const path = '~/a/b/c/d/e';
+    const result = truncatePath(path, 10);
+    expect(result.startsWith('~')).toBe(true);
+    expect(result).toContain('...');
+  });
+
+  it('should try to include more end parts when space allows', () => {
+    const path = '~/Projects/a/b/c/repo';
+    const result = truncatePath(path, 20);
+    expect(result).toContain('...');
+    expect(result.endsWith('repo')).toBe(true);
+  });
+});

--- a/src/lib/pathUtils.ts
+++ b/src/lib/pathUtils.ts
@@ -1,0 +1,37 @@
+/**
+ * Truncates a path in the middle if it exceeds maxLen.
+ * Detects the separator from the path itself.
+ *
+ * Examples:
+ *   truncatePath("~/Projects/very/deep/nested/repo", 25) => "~/Projects/.../nested/repo"
+ *   truncatePath("C:\\Users\\foo\\bar\\baz", 20) => "C:\\Users\\...\\baz"
+ */
+export function truncatePath(path: string, maxLen: number): string {
+  if (path.length <= maxLen) {
+    return path;
+  }
+
+  const sep = path.includes('\\') ? '\\' : '/';
+  const parts = path.split(sep);
+
+  if (parts.length <= 2) {
+    return path;
+  }
+
+  // Keep first and last parts, collapse middle with ...
+  const start = 1;
+  let end = parts.length - 1;
+  let result = [...parts.slice(0, start), '...', ...parts.slice(end)].join(sep);
+
+  // Try to include more parts from the end
+  while (end > start + 1) {
+    end--;
+    const candidate = [...parts.slice(0, start), '...', ...parts.slice(end)].join(sep);
+    if (candidate.length > maxLen) {
+      break;
+    }
+    result = candidate;
+  }
+
+  return result;
+}

--- a/src/services/api.ts
+++ b/src/services/api.ts
@@ -85,6 +85,10 @@ export const repositoryApi = {
   getRecentRepositories: () => commands.getRecentRepositories(),
 
   removeRecentRepository: (path: string) => commands.removeRecentRepository(path),
+
+  pinRepository: (path: string) => commands.pinRepository(path),
+
+  unpinRepository: (path: string) => commands.unpinRepository(path),
 };
 
 export const commitApi = {

--- a/src/store/repositoryStore.ts
+++ b/src/store/repositoryStore.ts
@@ -143,6 +143,8 @@ interface RepositoryState {
   loadWorktrees: () => Promise<void>;
   loadStatus: () => Promise<void>;
   loadRecentRepositories: () => Promise<void>;
+  pinRepository: (path: string) => Promise<void>;
+  unpinRepository: (path: string) => Promise<void>;
   setCurrentView: (view: ViewType) => void;
   clearError: () => void;
 
@@ -473,6 +475,24 @@ export const useRepositoryStore = create<RepositoryState>((set, get) => ({
       set({ recentRepositories });
     } catch (err) {
       set({ error: getErrorMessage(err) });
+    }
+  },
+
+  pinRepository: async (path: string) => {
+    try {
+      await repositoryApi.pinRepository(path);
+      await get().loadRecentRepositories();
+    } catch (err) {
+      toast.error(i18n.t('notifications.error.operationFailed'), getErrorMessage(err));
+    }
+  },
+
+  unpinRepository: async (path: string) => {
+    try {
+      await repositoryApi.unpinRepository(path);
+      await get().loadRecentRepositories();
+    } catch (err) {
+      toast.error(i18n.t('notifications.error.operationFailed'), getErrorMessage(err));
     }
   },
 


### PR DESCRIPTION
## Summary
This PR introduces a pinning feature for recent repositories, allowing users to enrich their experience by pinning important repositories for easier access. It includes updates to both the backend and frontend components to support this functionality.

## Changes
- **Added** pinning functionality for recent repositories in the backend.
- **Updated** the `RecentRepoContextMenu` and `RepoCard` components to support pinning.
- **Modified** various files to integrate pinning logic and state management.
- **Added** tests for new components and utility functions related to pinning.
- **Updated** localization files to reflect changes in the UI.