### PR TITLE
Enhance Git Hooks with Progress Tracking and Cancellation Support

### DIFF
--- a/src-tauri/src/events/hook_progress.rs
+++ b/src-tauri/src/events/hook_progress.rs
@@ -1,0 +1,166 @@
+use serde::{Deserialize, Serialize};
+use specta::Type;
+use strum::{Display, EnumString};
+use tauri_specta::Event;
+
+use crate::models::GitHookType;
+
+#[derive(Clone, Copy, Serialize, Deserialize, Type, Display, EnumString, Debug, PartialEq, Eq)]
+#[serde(rename_all = "PascalCase")]
+#[strum(serialize_all = "PascalCase")]
+pub enum HookStage {
+    Running,
+    Complete,
+    Failed,
+    Cancelled,
+}
+
+/// Progress update for hook execution
+#[derive(Clone, Serialize, Type, Event, Debug)]
+#[serde(rename_all = "camelCase")]
+pub struct HookProgressEvent {
+    pub operation_id: String,
+    pub hook_type: GitHookType,
+    pub stage: HookStage,
+    pub message: Option<String>,
+    pub can_abort: bool,
+}
+
+impl HookProgressEvent {
+    pub fn new(operation_id: String, hook_type: GitHookType, stage: HookStage) -> Self {
+        Self {
+            operation_id,
+            hook_type,
+            stage,
+            message: None,
+            can_abort: hook_type.can_abort(),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::str::FromStr;
+
+    // ==================== HookStage Tests ====================
+
+    #[test]
+    fn test_hook_stage_display() {
+        assert_eq!(HookStage::Running.to_string(), "Running");
+        assert_eq!(HookStage::Complete.to_string(), "Complete");
+        assert_eq!(HookStage::Failed.to_string(), "Failed");
+        assert_eq!(HookStage::Cancelled.to_string(), "Cancelled");
+    }
+
+    #[test]
+    fn test_hook_stage_from_str() {
+        assert_eq!(
+            HookStage::from_str("Running").expect("should parse"),
+            HookStage::Running
+        );
+        assert_eq!(
+            HookStage::from_str("Complete").expect("should parse"),
+            HookStage::Complete
+        );
+        assert_eq!(
+            HookStage::from_str("Failed").expect("should parse"),
+            HookStage::Failed
+        );
+        assert_eq!(
+            HookStage::from_str("Cancelled").expect("should parse"),
+            HookStage::Cancelled
+        );
+    }
+
+    #[test]
+    fn test_hook_stage_serialization() {
+        let stage = HookStage::Running;
+        let json = serde_json::to_string(&stage).expect("should serialize");
+        assert_eq!(json, "\"Running\"");
+
+        let stage = HookStage::Cancelled;
+        let json = serde_json::to_string(&stage).expect("should serialize");
+        assert_eq!(json, "\"Cancelled\"");
+    }
+
+    #[test]
+    fn test_hook_stage_deserialization() {
+        let stage: HookStage = serde_json::from_str("\"Running\"").expect("should deserialize");
+        assert_eq!(stage, HookStage::Running);
+
+        let stage: HookStage = serde_json::from_str("\"Failed\"").expect("should deserialize");
+        assert_eq!(stage, HookStage::Failed);
+    }
+
+    // ==================== HookProgressEvent Tests ====================
+
+    #[test]
+    fn test_hook_progress_event_new() {
+        let event = HookProgressEvent::new(
+            "op-123".to_string(),
+            GitHookType::PreCommit,
+            HookStage::Running,
+        );
+
+        assert_eq!(event.operation_id, "op-123");
+        assert_eq!(event.hook_type, GitHookType::PreCommit);
+        assert_eq!(event.stage, HookStage::Running);
+        assert!(event.message.is_none());
+        assert!(event.can_abort); // PreCommit can abort
+    }
+
+    #[test]
+    fn test_hook_progress_event_can_abort_true() {
+        let event =
+            HookProgressEvent::new("op".to_string(), GitHookType::PreCommit, HookStage::Running);
+        assert!(event.can_abort);
+
+        let event =
+            HookProgressEvent::new("op".to_string(), GitHookType::PrePush, HookStage::Running);
+        assert!(event.can_abort);
+
+        let event =
+            HookProgressEvent::new("op".to_string(), GitHookType::CommitMsg, HookStage::Running);
+        assert!(event.can_abort);
+    }
+
+    #[test]
+    fn test_hook_progress_event_can_abort_false() {
+        let event = HookProgressEvent::new(
+            "op".to_string(),
+            GitHookType::PostCommit,
+            HookStage::Running,
+        );
+        assert!(!event.can_abort);
+
+        let event =
+            HookProgressEvent::new("op".to_string(), GitHookType::PostMerge, HookStage::Running);
+        assert!(!event.can_abort);
+    }
+
+    #[test]
+    fn test_hook_progress_event_serialization() {
+        let event = HookProgressEvent::new(
+            "test-op".to_string(),
+            GitHookType::PreCommit,
+            HookStage::Complete,
+        );
+
+        let json = serde_json::to_string(&event).expect("should serialize");
+        assert!(json.contains("\"operationId\":\"test-op\""));
+        assert!(json.contains("\"hookType\":\"PreCommit\""));
+        assert!(json.contains("\"stage\":\"Complete\""));
+        assert!(json.contains("\"canAbort\":true"));
+    }
+
+    #[test]
+    fn test_hook_progress_event_with_message() {
+        let mut event =
+            HookProgressEvent::new("op".to_string(), GitHookType::PreCommit, HookStage::Failed);
+        event.message = Some("Lint failed".to_string());
+
+        let json = serde_json::to_string(&event).expect("should serialize");
+        assert!(json.contains("\"message\":\"Lint failed\""));
+    }
+}

--- a/src-tauri/src/events/mod.rs
+++ b/src-tauri/src/events/mod.rs
@@ -1,11 +1,13 @@
 mod file_watcher;
 mod git_progress;
+mod hook_progress;
 mod integrations;
 mod menu;
 mod update;
 
 pub use file_watcher::*;
 pub use git_progress::*;
+pub use hook_progress::*;
 pub use integrations::*;
 pub use menu::*;
 pub use update::*;

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -320,6 +320,7 @@ fn get_specta_builder() -> tauri_specta::Builder {
             crate::events::OAuthCallbackEvent,
             crate::events::IntegrationStatusChangedEvent,
             crate::events::GitOperationProgressEvent,
+            crate::events::HookProgressEvent,
             crate::events::UpdateDownloadProgressEvent
         ])
 }

--- a/src-tauri/src/services/hook_progress.rs
+++ b/src-tauri/src/services/hook_progress.rs
@@ -28,11 +28,6 @@ impl HookProgressEmitter {
         }
     }
 
-    /// Get the operation ID
-    pub fn operation_id(&self) -> &str {
-        &self.operation_id
-    }
-
     /// Check if the operation was cancelled
     pub fn is_cancelled(&self) -> bool {
         self.cancel_token.load(Ordering::SeqCst)

--- a/src-tauri/src/services/hook_progress.rs
+++ b/src-tauri/src/services/hook_progress.rs
@@ -1,0 +1,111 @@
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::Arc;
+
+use tauri::AppHandle;
+use tauri_specta::Event;
+
+use crate::events::{HookProgressEvent, HookStage};
+use crate::models::GitHookType;
+use crate::services::ProgressRegistry;
+
+/// Emitter for hook progress events with cancellation support
+pub struct HookProgressEmitter {
+    operation_id: String,
+    app_handle: AppHandle,
+    cancel_token: Arc<AtomicBool>,
+    registry: Arc<ProgressRegistry>,
+}
+
+impl HookProgressEmitter {
+    pub fn new(app_handle: AppHandle, registry: Arc<ProgressRegistry>) -> Self {
+        let operation_id = uuid::Uuid::new_v4().to_string();
+        let cancel_token = registry.register(&operation_id);
+        Self {
+            operation_id,
+            app_handle,
+            cancel_token,
+            registry,
+        }
+    }
+
+    /// Get the operation ID
+    pub fn operation_id(&self) -> &str {
+        &self.operation_id
+    }
+
+    /// Check if the operation was cancelled
+    pub fn is_cancelled(&self) -> bool {
+        self.cancel_token.load(Ordering::SeqCst)
+    }
+
+    /// Emit a running event
+    pub fn emit_running(&self, hook_type: GitHookType) {
+        let event =
+            HookProgressEvent::new(self.operation_id.clone(), hook_type, HookStage::Running);
+        if let Err(e) = event.emit(&self.app_handle) {
+            log::error!("Failed to emit hook running event: {e}");
+        }
+    }
+
+    /// Emit a complete event
+    pub fn emit_complete(&self, hook_type: GitHookType) {
+        let event =
+            HookProgressEvent::new(self.operation_id.clone(), hook_type, HookStage::Complete);
+        if let Err(e) = event.emit(&self.app_handle) {
+            log::error!("Failed to emit hook complete event: {e}");
+        }
+    }
+
+    /// Emit a failed event with message
+    pub fn emit_failed(&self, hook_type: GitHookType, message: &str) {
+        let mut event =
+            HookProgressEvent::new(self.operation_id.clone(), hook_type, HookStage::Failed);
+        event.message = Some(message.to_string());
+        if let Err(e) = event.emit(&self.app_handle) {
+            log::error!("Failed to emit hook failed event: {e}");
+        }
+    }
+
+    /// Emit a cancelled event
+    pub fn emit_cancelled(&self, hook_type: GitHookType) {
+        let event =
+            HookProgressEvent::new(self.operation_id.clone(), hook_type, HookStage::Cancelled);
+        if let Err(e) = event.emit(&self.app_handle) {
+            log::error!("Failed to emit hook cancelled event: {e}");
+        }
+    }
+}
+
+impl Drop for HookProgressEmitter {
+    fn drop(&mut self) {
+        self.registry.cleanup(&self.operation_id);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // ==================== HookProgressEmitter Tests ====================
+
+    #[test]
+    fn test_operation_id_is_uuid() {
+        // We can't fully test without AppHandle, but we can verify the UUID format
+        let uuid = uuid::Uuid::new_v4().to_string();
+        assert_eq!(uuid.len(), 36); // UUID v4 string length
+        assert!(uuid.contains('-'));
+    }
+
+    #[test]
+    fn test_cancel_token_initial_state() {
+        let token = Arc::new(AtomicBool::new(false));
+        assert!(!token.load(Ordering::SeqCst));
+    }
+
+    #[test]
+    fn test_cancel_token_cancelled_state() {
+        let token = Arc::new(AtomicBool::new(false));
+        token.store(true, Ordering::SeqCst);
+        assert!(token.load(Ordering::SeqCst));
+    }
+}

--- a/src-tauri/src/services/mod.rs
+++ b/src-tauri/src/services/mod.rs
@@ -7,6 +7,7 @@ mod file_watcher;
 mod git2_service;
 mod git_cli_service;
 mod git_service;
+mod hook_progress;
 mod hook_service;
 mod integrations;
 #[cfg(feature = "integration")]
@@ -27,6 +28,7 @@ pub use file_watcher::*;
 pub use git2_service::*;
 pub use git_cli_service::*;
 pub use git_service::*;
+pub use hook_progress::*;
 pub use hook_service::*;
 pub use integrations::*;
 pub use process_utils::*;

--- a/src-tauri/src/services/ops/hooks.rs
+++ b/src-tauri/src/services/ops/hooks.rs
@@ -19,19 +19,24 @@ impl RepoOperations {
         msg_file: &Path,
         source: Option<&str>,
         sha: Option<&str>,
+        emitter: Option<&HookProgressEmitter>,
     ) -> HookResult {
         self.service
             .hook()
-            .run_prepare_commit_msg(msg_file, source, sha)
+            .run_prepare_commit_msg(msg_file, source, sha, emitter)
             .await
     }
 
-    pub async fn run_commit_msg(&self, msg_file: &Path) -> HookResult {
-        self.service.hook().run_commit_msg(msg_file).await
+    pub async fn run_commit_msg(
+        &self,
+        msg_file: &Path,
+        emitter: Option<&HookProgressEmitter>,
+    ) -> HookResult {
+        self.service.hook().run_commit_msg(msg_file, emitter).await
     }
 
-    pub async fn run_post_commit(&self) -> HookResult {
-        self.service.hook().run_post_commit().await
+    pub async fn run_post_commit(&self, emitter: Option<&HookProgressEmitter>) -> HookResult {
+        self.service.hook().run_post_commit(emitter).await
     }
 
     pub async fn run_pre_push(
@@ -39,21 +44,31 @@ impl RepoOperations {
         remote_name: &str,
         remote_url: &str,
         refs_stdin: &str,
+        emitter: Option<&HookProgressEmitter>,
     ) -> HookResult {
         self.service
             .hook()
-            .run_pre_push(remote_name, remote_url, refs_stdin)
+            .run_pre_push(remote_name, remote_url, refs_stdin, emitter)
             .await
     }
 
-    pub async fn run_post_merge(&self, is_squash: bool) -> HookResult {
-        self.service.hook().run_post_merge(is_squash).await
+    pub async fn run_post_merge(
+        &self,
+        is_squash: bool,
+        emitter: Option<&HookProgressEmitter>,
+    ) -> HookResult {
+        self.service.hook().run_post_merge(is_squash, emitter).await
     }
 
-    pub async fn run_pre_rebase(&self, upstream: &str, rebased_branch: Option<&str>) -> HookResult {
+    pub async fn run_pre_rebase(
+        &self,
+        upstream: &str,
+        rebased_branch: Option<&str>,
+        emitter: Option<&HookProgressEmitter>,
+    ) -> HookResult {
         self.service
             .hook()
-            .run_pre_rebase(upstream, rebased_branch)
+            .run_pre_rebase(upstream, rebased_branch, emitter)
             .await
     }
 
@@ -62,17 +77,23 @@ impl RepoOperations {
         prev_head: &str,
         new_head: &str,
         is_branch: bool,
+        emitter: Option<&HookProgressEmitter>,
     ) -> HookResult {
         self.service
             .hook()
-            .run_post_checkout(prev_head, new_head, is_branch)
+            .run_post_checkout(prev_head, new_head, is_branch, emitter)
             .await
     }
 
-    pub async fn run_post_rewrite(&self, command: &str, rewrites_stdin: &str) -> HookResult {
+    pub async fn run_post_rewrite(
+        &self,
+        command: &str,
+        rewrites_stdin: &str,
+        emitter: Option<&HookProgressEmitter>,
+    ) -> HookResult {
         self.service
             .hook()
-            .run_post_rewrite(command, rewrites_stdin)
+            .run_post_rewrite(command, rewrites_stdin, emitter)
             .await
     }
 

--- a/src-tauri/src/services/ops/hooks.rs
+++ b/src-tauri/src/services/ops/hooks.rs
@@ -1,6 +1,8 @@
+use std::path::Path;
+
 use crate::error::Result;
 use crate::models::{GitHookType, HookDetails, HookInfo, HookResult, HookTemplate};
-use std::path::Path;
+use crate::services::HookProgressEmitter;
 
 use super::RepoOperations;
 
@@ -8,8 +10,8 @@ use super::RepoOperations;
 impl RepoOperations {
     // ---- Execution (async) ----
 
-    pub async fn run_pre_commit(&self) -> HookResult {
-        self.service.hook().run_pre_commit().await
+    pub async fn run_pre_commit(&self, emitter: Option<&HookProgressEmitter>) -> HookResult {
+        self.service.hook().run_pre_commit(emitter).await
     }
 
     pub async fn run_prepare_commit_msg(

--- a/src/bindings/api.ts
+++ b/src/bindings/api.ts
@@ -1169,6 +1169,7 @@ export const events = __makeEvents__<{
 filesChangedEvent: FilesChangedEvent,
 gitOperationProgressEvent: GitOperationProgressEvent,
 headChangedEvent: HeadChangedEvent,
+hookProgressEvent: HookProgressEvent,
 indexChangedEvent: IndexChangedEvent,
 integrationStatusChangedEvent: IntegrationStatusChangedEvent,
 menuActionEvent: MenuActionEvent,
@@ -1182,6 +1183,7 @@ watchErrorEvent: WatchErrorEvent
 filesChangedEvent: "files-changed-event",
 gitOperationProgressEvent: "git-operation-progress-event",
 headChangedEvent: "head-changed-event",
+hookProgressEvent: "hook-progress-event",
 indexChangedEvent: "index-changed-event",
 integrationStatusChangedEvent: "integration-status-changed-event",
 menuActionEvent: "menu-action-event",
@@ -1411,7 +1413,7 @@ prefix: string | null }
 export type ArchiveResult = { message: string; outputPath: string | null; sizeBytes: number | null }
 export type AvatarResponse = { source: AvatarSource; path: string | null }
 export type AvatarSource = "Integration" | "Gravatar" | "Default"
-export type AxisError = { type: "RepositoryNotFound"; data: string } | { type: "RepositoryAlreadyOpen"; data: string } | { type: "InvalidRepositoryPath"; data: string } | { type: "GitError"; data: string } | { type: "IoError"; data: string } | { type: "DatabaseError"; data: string } | { type: "SerializationError"; data: string } | { type: "InvalidReference"; data: string } | { type: "NoRepositoryOpen" } | { type: "BranchNotFound"; data: string } | { type: "BranchNotMerged"; data: string } | { type: "RemoteNotFound"; data: string } | { type: "FileNotFound"; data: string } | { type: "CannotFastForward" } | { type: "RebaseRequired" } | { type: "MergeConflict" } | { type: "CheckoutConflict"; data: string[] } | { type: "StashApplyConflict"; data: string[] } | { type: "AuthenticationFailed"; data: string } | { type: "AiServiceError"; data: string } | { type: "ApiKeyNotConfigured"; data: string } | { type: "DiffTooLarge"; data: number } | { type: "Other"; data: string } | { type: "IntegrationNotConnected"; data: string } | { type: "IntegrationError"; data: string } | { type: "ProviderNotDetected" } | { type: "OAuthError"; data: string } | { type: "OAuthCancelled" } | { type: "SshKeyError"; data: string } | { type: "SshKeyAlreadyExists"; data: string } | { type: "SshKeygenNotFound" } | { type: "InvalidKeyFilename"; data: string }
+export type AxisError = { type: "RepositoryNotFound"; data: string } | { type: "InvalidRepositoryPath"; data: string } | { type: "GitError"; data: string } | { type: "IoError"; data: string } | { type: "DatabaseError"; data: string } | { type: "SerializationError"; data: string } | { type: "InvalidReference"; data: string } | { type: "NoRepositoryOpen" } | { type: "BranchNotFound"; data: string } | { type: "BranchNotMerged"; data: string } | { type: "RemoteNotFound"; data: string } | { type: "FileNotFound"; data: string } | { type: "CannotFastForward" } | { type: "RebaseRequired" } | { type: "MergeConflict" } | { type: "CheckoutConflict"; data: string[] } | { type: "StashApplyConflict"; data: string[] } | { type: "AuthenticationFailed"; data: string } | { type: "AiServiceError"; data: string } | { type: "ApiKeyNotConfigured"; data: string } | { type: "DiffTooLarge"; data: number } | { type: "Other"; data: string } | { type: "IntegrationNotConnected"; data: string } | { type: "IntegrationError"; data: string } | { type: "ProviderNotDetected" } | { type: "OAuthError"; data: string } | { type: "OAuthCancelled" } | { type: "SshKeyError"; data: string } | { type: "SshKeyAlreadyExists"; data: string } | { type: "SshKeygenNotFound" } | { type: "InvalidKeyFilename"; data: string }
 /**
  * Mark type for bisect marking operations
  */
@@ -2314,6 +2316,11 @@ path: string;
  * Whether the hook file is executable (Unix only, always true on Windows)
  */
 isExecutable: boolean }
+/**
+ * Progress update for hook execution
+ */
+export type HookProgressEvent = { operationId: string; hookType: GitHookType; stage: HookStage; message: string | null; canAbort: boolean }
+export type HookStage = "Running" | "Complete" | "Failed" | "Cancelled"
 /**
  * Template for creating hooks
  */

--- a/src/components/layout/AppLayout.test.tsx
+++ b/src/components/layout/AppLayout.test.tsx
@@ -167,6 +167,7 @@ vi.mock('../settings/RepositorySettingsDialog', () => ({
 vi.mock('../../hooks', () => ({
   useFileWatcher: vi.fn(),
   useGitProgress: vi.fn(),
+  useHookProgress: vi.fn(),
 }));
 
 const mockLoadTags = vi.fn().mockResolvedValue(undefined);

--- a/src/components/layout/AppLayout.tsx
+++ b/src/components/layout/AppLayout.tsx
@@ -34,7 +34,7 @@ import { SettingsDialog } from '../settings/SettingsDialog';
 import { RepositorySettingsDialog } from '../settings/RepositorySettingsDialog';
 import { useRepositoryStore } from '../../store/repositoryStore';
 import { useDialogStore } from '../../store/dialogStore';
-import { useFileWatcher, useGitProgress } from '../../hooks';
+import { useFileWatcher, useGitProgress, useHookProgress } from '../../hooks';
 
 interface AppLayoutProps {
   children: ReactNode;
@@ -45,6 +45,8 @@ export function AppLayout({ children }: AppLayoutProps) {
   useFileWatcher();
   // Listen for git operation progress events
   useGitProgress();
+  // Listen for hook progress events
+  useHookProgress();
 
   const {
     checkoutConflict,

--- a/src/components/ui/operations-indicator.tsx
+++ b/src/components/ui/operations-indicator.tsx
@@ -1,8 +1,9 @@
 import { useState, useEffect, useRef, startTransition } from 'react';
 import { useTranslation } from 'react-i18next';
-import { Loader2 } from 'lucide-react';
+import { Loader2, X } from 'lucide-react';
 
 import { cn } from '@/lib/utils';
+import { shellApi } from '@/services/api';
 import { useOperationStore, type Operation, type OperationProgress } from '@/store/operationStore';
 import { ProgressStage } from '@/types';
 
@@ -66,6 +67,14 @@ function OperationItem({ operation }: { operation: Operation }) {
     return () => clearInterval(interval);
   }, []);
 
+  const handleCancel = async () => {
+    try {
+      await shellApi.cancelOperation(operation.id);
+    } catch (err) {
+      console.warn('Failed to cancel operation:', err);
+    }
+  };
+
   const progress = operation.progress;
   const percent = progress ? getProgressPercent(progress) : 0;
 
@@ -87,6 +96,11 @@ function OperationItem({ operation }: { operation: Operation }) {
         )}
       </div>
       <div className="operations-item-time">{formatDuration(operation.startedAt)}</div>
+      {operation.cancellable && (
+        <button className="operations-cancel-btn" onClick={handleCancel}>
+          <X size={14} />
+        </button>
+      )}
     </div>
   );
 }

--- a/src/hooks/index.ts
+++ b/src/hooks/index.ts
@@ -2,6 +2,7 @@ export { useKeyboardShortcuts, KEYBOARD_SHORTCUTS } from './useKeyboardShortcuts
 export { useCustomActionShortcuts } from './useCustomActionShortcuts';
 export { useFileWatcher } from './useFileWatcher';
 export { useGitProgress } from './useGitProgress';
+export { useHookProgress } from './useHookProgress';
 export { useMenuActions } from './useMenuActions';
 export { useOperation } from './useOperation';
 export { useOperationProgress } from './useOperationProgress';

--- a/src/hooks/useHookProgress.ts
+++ b/src/hooks/useHookProgress.ts
@@ -1,0 +1,49 @@
+import { useEffect, useRef } from 'react';
+import { UnlistenFn } from '@tauri-apps/api/event';
+
+import { events } from '@/bindings/api';
+import i18n from '@/i18n';
+import { operations } from '@/store/operationStore';
+import { HookStage } from '@/types';
+
+function getHookName(hookType: string): string {
+  return i18n.t(`settings.hooks.labels.${hookType}`);
+}
+
+export function useHookProgress() {
+  const unlistenRef = useRef<UnlistenFn | null>(null);
+
+  useEffect(() => {
+    const setupListener = async () => {
+      unlistenRef.current = await events.hookProgressEvent.listen((event) => {
+        const { operationId, hookType, stage, message } = event.payload;
+
+        const isTerminal =
+          stage === HookStage.Complete ||
+          stage === HookStage.Failed ||
+          stage === HookStage.Cancelled;
+
+        if (isTerminal) {
+          operations.complete(operationId);
+          return;
+        }
+
+        operations.start(getHookName(hookType), {
+          id: operationId,
+          category: 'hook',
+          cancellable: true,
+          description: message ?? undefined,
+        });
+      });
+    };
+
+    setupListener();
+
+    return () => {
+      if (unlistenRef.current) {
+        unlistenRef.current();
+        unlistenRef.current = null;
+      }
+    };
+  }, []);
+}

--- a/src/hooks/useHookProgress.ts
+++ b/src/hooks/useHookProgress.ts
@@ -7,7 +7,7 @@ import { operations } from '@/store/operationStore';
 import { HookStage } from '@/types';
 
 function getHookName(hookType: string): string {
-  return i18n.t(`settings.hooks.labels.${hookType}`);
+  return i18n.t(`repoSettings.hooks.labels.${hookType}`);
 }
 
 export function useHookProgress() {

--- a/src/index.css
+++ b/src/index.css
@@ -844,6 +844,10 @@ code {
     @apply text-xs text-(--text-secondary) mt-1;
   }
 
+  .operations-cancel-btn {
+    @apply shrink-0 p-1 rounded text-(--text-tertiary) hover:text-(--text-primary) hover:bg-(--bg-tertiary) transition-colors;
+  }
+
   /* Dropdown classes (Radix UI) */
   .dropdown-button {
     @apply flex items-center gap-1 py-1 px-2 border border-(--border-color) bg-(--bg-secondary) text-(--text-primary) text-xs cursor-pointer rounded transition-colors hover:bg-(--bg-hover);

--- a/src/store/operationStore.ts
+++ b/src/store/operationStore.ts
@@ -1,7 +1,7 @@
 import type { GitOperationType, ProgressStage } from '@/types';
 import { create } from 'zustand';
 
-export type OperationCategory = 'git' | 'file' | 'network' | 'general';
+export type OperationCategory = 'git' | 'file' | 'network' | 'hook' | 'general';
 
 export interface OperationProgress {
   stage: ProgressStage;

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -267,6 +267,7 @@ import type {
   GitOperationType as GitOperationTypeType,
   // Hook types
   GitHookType as GitHookTypeType,
+  HookStage as HookStageType,
   // SSH Key types
   SshKeyAlgorithm as SshKeyAlgorithmType,
   SshKeyFormat as SshKeyFormatType,
@@ -680,6 +681,16 @@ export const GitHookType: { [K in GitHookTypeType]: K } = {
 };
 
 export type GitHookType = GitHookTypeType;
+
+// Hook stage enum helpers
+export const HookStage: { [K in HookStageType]: K } = {
+  Running: 'Running',
+  Complete: 'Complete',
+  Failed: 'Failed',
+  Cancelled: 'Cancelled',
+};
+
+export type HookStage = HookStageType;
 
 // Custom actions enum helpers
 export const ActionContext: { [K in ActionContextType]: K } = {


### PR DESCRIPTION
## Summary
This PR improves the Git hooks functionality by adding a hook progress emitter for better tracking and cancellation support. It also removes an unused method and updates the hook name translation path for consistency with repository settings.

## Changes
- **Removed** unused `operation_id` method from `HookProgressEmitter`.
- **Added** hook progress emitter to various Git command hooks.
- **Updated** hook name translation path for consistency with repo settings.
- **Implemented** hook progress events with cancellation support for Git hooks.
- **Modified** multiple command and service files to integrate the new hook progress functionality.