### PR TITLE
Implement "Mark Conflict Unresolved" Command and UI Enhancements

### DIFF
--- a/src-tauri/src/commands/merge.rs
+++ b/src-tauri/src/commands/merge.rs
@@ -729,6 +729,19 @@ pub async fn mark_conflict_resolved(state: State<'_, AppState>, path: String) ->
     Ok(())
 }
 
+/// Mark a file as unresolved (restore conflict markers)
+#[tauri::command]
+#[specta::specta]
+pub async fn mark_conflict_unresolved(state: State<'_, AppState>, path: String) -> Result<()> {
+    state
+        .get_git_service()?
+        .write()
+        .await
+        .mark_unresolved(&path)
+        .await?;
+    Ok(())
+}
+
 // ==================== Operation State Commands ====================
 
 /// Get the current operation in progress

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -124,6 +124,7 @@ fn get_specta_builder() -> tauri_specta::Builder {
             crate::commands::get_conflict_content,
             crate::commands::resolve_conflict,
             crate::commands::mark_conflict_resolved,
+            crate::commands::mark_conflict_unresolved,
             // Operation state
             crate::commands::get_operation_state,
             // Bisect commands

--- a/src-tauri/src/services/git_cli_service.rs
+++ b/src-tauri/src/services/git_cli_service.rs
@@ -38,6 +38,7 @@ pub struct GitCliService {
     repo_path: std::path::PathBuf,
 }
 
+#[cfg(test)]
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum OperationType {
     Merge,

--- a/src-tauri/src/services/ops/merge.rs
+++ b/src-tauri/src/services/ops/merge.rs
@@ -117,6 +117,10 @@ impl RepoOperations {
         self.service.git_cli().mark_resolved(path).await
     }
 
+    pub async fn mark_unresolved(&self, path: &str) -> Result<GitCommandResult> {
+        self.service.git_cli().mark_unresolved(path).await
+    }
+
     pub async fn get_conflict_base(&self, path: &str) -> Result<String> {
         self.service.git_cli().get_conflict_base(path).await
     }

--- a/src/bindings/api.ts
+++ b/src/bindings/api.ts
@@ -388,6 +388,12 @@ async markConflictResolved(path: string) : Promise<null> {
     return await TAURI_INVOKE("mark_conflict_resolved", { path });
 },
 /**
+ * Mark a file as unresolved (restore conflict markers)
+ */
+async markConflictUnresolved(path: string) : Promise<null> {
+    return await TAURI_INVOKE("mark_conflict_unresolved", { path });
+},
+/**
  * Get the current operation in progress
  */
 async getOperationState() : Promise<OperationState> {

--- a/src/components/merge/ConflictResolver.test.tsx
+++ b/src/components/merge/ConflictResolver.test.tsx
@@ -20,12 +20,16 @@ const mockGetConflictedFiles = vi.fn();
 const mockGetState = vi.fn();
 const mockGetConflictContent = vi.fn();
 const mockResolveConflict = vi.fn();
+const mockMarkResolved = vi.fn();
+const mockMarkUnresolved = vi.fn();
 
 vi.mock('@/services/api', () => ({
   conflictApi: {
     getConflictedFiles: () => mockGetConflictedFiles(),
     getConflictContent: (path: string) => mockGetConflictContent(path),
     resolveConflict: (...args: unknown[]) => mockResolveConflict(...args),
+    markResolved: (path: string) => mockMarkResolved(path),
+    markUnresolved: (path: string) => mockMarkUnresolved(path),
   },
   operationApi: {
     getState: () => mockGetState(),
@@ -216,6 +220,26 @@ describe('ConflictResolver', () => {
 
     await waitFor(() => {
       expect(screen.getByText('src/file1.ts')).toBeInTheDocument();
+    });
+  });
+
+  it('should render mark unresolved button for resolved files', async () => {
+    mockGetConflictedFiles.mockResolvedValue([{ path: 'src/file1.ts', isResolved: true }]);
+
+    render(<ConflictResolver />);
+
+    await waitFor(() => {
+      expect(screen.getByText('merge.conflictResolver.markUnresolved')).toBeInTheDocument();
+    });
+  });
+
+  it('should render mark resolved button for unresolved files', async () => {
+    mockGetConflictedFiles.mockResolvedValue([{ path: 'src/file1.ts', isResolved: false }]);
+
+    render(<ConflictResolver />);
+
+    await waitFor(() => {
+      expect(screen.getByText('merge.conflictResolver.markResolved')).toBeInTheDocument();
     });
   });
 });

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -845,6 +845,8 @@
       "useThis": "Use This",
       "merged": "Merged Result",
       "markResolved": "Mark Resolved",
+      "markUnresolved": "Mark Unresolved",
+      "failedUnresolve": "Failed to unresolve conflict",
       "deleted": "(deleted)",
       "operations": {
         "merging": "Merging",

--- a/src/services/api.ts
+++ b/src/services/api.ts
@@ -303,6 +303,8 @@ export const conflictApi = {
     commands.resolveConflict(path, resolution, customContent ?? null),
 
   markResolved: (path: string) => commands.markConflictResolved(path),
+
+  markUnresolved: (path: string) => commands.markConflictUnresolved(path),
 };
 
 export const operationApi = {


### PR DESCRIPTION
## Summary
This PR introduces a new command to mark merge conflicts as unresolved, along with the necessary UI updates to support this functionality. It enhances the user experience during conflict resolution in the merge process.

## Changes
- Added a command to mark conflicts as unresolved in `merge.rs`.
- Updated UI components in `ConflictResolver.tsx` to reflect the new command.
- Modified related tests in `ConflictResolver.test.tsx` to ensure proper functionality.
- Updated API bindings in `api.ts` to include the new command.
- Enhanced localization support in `en.json` for the new feature.