### PR TITLE
Refactor GitFlow and GitHook Types for Improved String Conversion

### DIFF
--- a/src-tauri/src/models/gitflow.rs
+++ b/src-tauri/src/models/gitflow.rs
@@ -1,5 +1,6 @@
 use serde::{Deserialize, Serialize};
 use specta::Type;
+use strum::{AsRefStr, Display};
 
 /// Git-flow configuration
 #[derive(Debug, Clone, Serialize, Deserialize, Type)]
@@ -86,25 +87,14 @@ pub struct GitFlowResult {
 }
 
 /// Type of git-flow branch
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, Type)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, Type, Display, AsRefStr)]
 #[serde(rename_all = "PascalCase")]
+#[strum(serialize_all = "lowercase")]
 pub enum GitFlowBranchType {
     Feature,
     Release,
     Hotfix,
     Support,
-}
-
-impl GitFlowBranchType {
-    #[must_use]
-    pub fn as_str(self) -> &'static str {
-        match self {
-            GitFlowBranchType::Feature => "feature",
-            GitFlowBranchType::Release => "release",
-            GitFlowBranchType::Hotfix => "hotfix",
-            GitFlowBranchType::Support => "support",
-        }
-    }
 }
 
 /// Content search options
@@ -329,11 +319,11 @@ mod tests {
     // ==================== GitFlowBranchType Tests ====================
 
     #[test]
-    fn test_git_flow_branch_type_as_str() {
-        assert_eq!(GitFlowBranchType::Feature.as_str(), "feature");
-        assert_eq!(GitFlowBranchType::Release.as_str(), "release");
-        assert_eq!(GitFlowBranchType::Hotfix.as_str(), "hotfix");
-        assert_eq!(GitFlowBranchType::Support.as_str(), "support");
+    fn test_git_flow_branch_type_display() {
+        assert_eq!(GitFlowBranchType::Feature.to_string(), "feature");
+        assert_eq!(GitFlowBranchType::Release.to_string(), "release");
+        assert_eq!(GitFlowBranchType::Hotfix.to_string(), "hotfix");
+        assert_eq!(GitFlowBranchType::Support.to_string(), "support");
     }
 
     #[test]

--- a/src-tauri/src/models/hooks.rs
+++ b/src-tauri/src/models/hooks.rs
@@ -42,22 +42,6 @@ impl GitHookType {
                 | Self::PreRebase
         )
     }
-
-    /// Get the hook filename
-    #[must_use]
-    pub fn filename(self) -> &'static str {
-        match self {
-            GitHookType::PreCommit => "pre-commit",
-            GitHookType::PrepareCommitMsg => "prepare-commit-msg",
-            GitHookType::CommitMsg => "commit-msg",
-            GitHookType::PostCommit => "post-commit",
-            GitHookType::PrePush => "pre-push",
-            GitHookType::PostMerge => "post-merge",
-            GitHookType::PreRebase => "pre-rebase",
-            GitHookType::PostCheckout => "post-checkout",
-            GitHookType::PostRewrite => "post-rewrite",
-        }
-    }
 }
 
 /// Result of running a git hook
@@ -402,22 +386,6 @@ mod tests {
         assert!(!GitHookType::PostMerge.can_abort());
         assert!(!GitHookType::PostCheckout.can_abort());
         assert!(!GitHookType::PostRewrite.can_abort());
-    }
-
-    #[test]
-    fn test_git_hook_type_filename() {
-        assert_eq!(GitHookType::PreCommit.filename(), "pre-commit");
-        assert_eq!(
-            GitHookType::PrepareCommitMsg.filename(),
-            "prepare-commit-msg"
-        );
-        assert_eq!(GitHookType::CommitMsg.filename(), "commit-msg");
-        assert_eq!(GitHookType::PostCommit.filename(), "post-commit");
-        assert_eq!(GitHookType::PrePush.filename(), "pre-push");
-        assert_eq!(GitHookType::PostMerge.filename(), "post-merge");
-        assert_eq!(GitHookType::PreRebase.filename(), "pre-rebase");
-        assert_eq!(GitHookType::PostCheckout.filename(), "post-checkout");
-        assert_eq!(GitHookType::PostRewrite.filename(), "post-rewrite");
     }
 
     #[test]

--- a/src-tauri/src/models/integration.rs
+++ b/src-tauri/src/models/integration.rs
@@ -1,7 +1,7 @@
 use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize};
 use specta::Type;
-use strum::Display;
+use strum::{Display, EnumString};
 
 /// Supported integration providers
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize, Type, Display)]
@@ -155,8 +155,9 @@ pub struct CreateIssueOptions {
 }
 
 /// CI/CD run status
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, Type)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, Type, EnumString)]
 #[serde(rename_all = "PascalCase")]
+#[strum(serialize_all = "snake_case")]
 pub enum CIRunStatus {
     Queued,
     InProgress,
@@ -164,8 +165,9 @@ pub enum CIRunStatus {
 }
 
 /// CI/CD run conclusion
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, Type)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, Type, EnumString)]
 #[serde(rename_all = "PascalCase")]
+#[strum(serialize_all = "snake_case")]
 pub enum CIConclusion {
     Success,
     Failure,
@@ -226,8 +228,9 @@ pub struct NotificationsPage {
 }
 
 /// Combined commit status
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, Type)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, Type, EnumString)]
 #[serde(rename_all = "PascalCase")]
+#[strum(serialize_all = "snake_case")]
 pub enum CommitStatusState {
     Pending,
     Success,
@@ -245,9 +248,11 @@ pub struct CommitStatus {
 }
 
 /// Notification reason
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, Type)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, Type, EnumString)]
 #[serde(rename_all = "PascalCase")]
+#[strum(serialize_all = "snake_case")]
 pub enum NotificationReason {
+    #[strum(serialize = "assign")]
     Assigned,
     Author,
     Comment,
@@ -263,7 +268,7 @@ pub enum NotificationReason {
 }
 
 /// Notification subject type
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, Type)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, Type, EnumString)]
 #[serde(rename_all = "PascalCase")]
 pub enum NotificationSubjectType {
     Issue,

--- a/src-tauri/src/models/signing.rs
+++ b/src-tauri/src/models/signing.rs
@@ -1,27 +1,17 @@
 use serde::{Deserialize, Serialize};
 use specta::Type;
-use strum::Display;
+use strum::{Display, EnumString};
 
 /// Signing format - GPG (`OpenPGP`) or SSH
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Default, Type, Display)]
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Default, Type, Display, EnumString)]
 #[serde(rename_all = "PascalCase")]
-#[strum(serialize_all = "lowercase")]
+#[strum(ascii_case_insensitive)]
 pub enum SigningFormat {
     #[default]
+    #[strum(to_string = "gpg", serialize = "openpgp")]
     Gpg,
+    #[strum(serialize = "ssh")]
     Ssh,
-}
-
-impl std::str::FromStr for SigningFormat {
-    type Err = String;
-
-    fn from_str(s: &str) -> std::result::Result<Self, Self::Err> {
-        match s.to_lowercase().as_str() {
-            "gpg" | "openpgp" => Ok(SigningFormat::Gpg),
-            "ssh" => Ok(SigningFormat::Ssh),
-            _ => Err(format!("Unknown signing format: {s}")),
-        }
-    }
 }
 
 /// Configuration for commit signing (how to sign, not whether to sign)
@@ -156,8 +146,6 @@ mod tests {
     fn test_signing_format_from_str_invalid() {
         let result: Result<SigningFormat, _> = "invalid".parse();
         assert!(result.is_err());
-        let err = result.expect_err("should be error");
-        assert!(err.contains("Unknown signing format"));
     }
 
     // ==================== SigningConfig Tests ====================

--- a/src-tauri/src/services/git_cli_service.rs
+++ b/src-tauri/src/services/git_cli_service.rs
@@ -1464,7 +1464,7 @@ impl GitCliService {
 
         Ok(GitFlowResult {
             success: true,
-            message: format!("Started {} '{name}'", branch_type.as_str()),
+            message: format!("Started {branch_type} '{name}'"),
             branch: Some(branch_name),
         })
     }
@@ -1581,7 +1581,7 @@ impl GitCliService {
 
         Ok(GitFlowResult {
             success: true,
-            message: format!("Finished {} '{name}'", branch_type.as_str()),
+            message: format!("Finished {branch_type} '{name}'"),
             branch: Some(target_branch),
         })
     }
@@ -1620,7 +1620,7 @@ impl GitCliService {
 
         Ok(GitFlowResult {
             success: true,
-            message: format!("Published {} '{name}' to origin", branch_type.as_str()),
+            message: format!("Published {branch_type} '{name}' to origin"),
             branch: Some(branch_name),
         })
     }

--- a/src-tauri/src/services/hook_service.rs
+++ b/src-tauri/src/services/hook_service.rs
@@ -61,7 +61,7 @@ impl HookService {
     #[cfg(test)]
     /// Check if a hook exists and is executable
     fn hook_exists(&self, hook_type: GitHookType) -> bool {
-        let hook_path = self.hooks_path.join(hook_type.filename());
+        let hook_path = self.hooks_path.join(hook_type.to_string());
         if !hook_path.exists() || !hook_path.is_file() {
             return false;
         }
@@ -89,7 +89,7 @@ impl HookService {
         stdin_data: Option<&str>,
         emitter: Option<&HookProgressEmitter>,
     ) -> HookResult {
-        let hook_path = self.hooks_path.join(hook_type.filename());
+        let hook_path = self.hooks_path.join(hook_type.to_string());
 
         // Check if hook exists
         if !hook_path.exists() || !hook_path.is_file() {
@@ -391,8 +391,8 @@ impl HookService {
 
     /// Get info for a specific hook
     pub fn get_hook_info(&self, hook_type: GitHookType) -> HookInfo {
-        let filename = hook_type.filename();
-        let hook_path = self.hooks_path.join(filename);
+        let filename = hook_type.to_string();
+        let hook_path = self.hooks_path.join(&filename);
         let disabled_path = self.hooks_path.join(format!("{filename}.disabled"));
 
         let (exists, enabled, actual_path) = if hook_path.exists() && hook_path.is_file() {
@@ -446,14 +446,11 @@ impl HookService {
         // Ensure hooks directory exists
         fs::create_dir_all(&self.hooks_path).map_err(AxisError::from)?;
 
-        let hook_path = self.hooks_path.join(hook_type.filename());
+        let hook_path = self.hooks_path.join(hook_type.to_string());
 
         // Check if hook already exists
         if hook_path.exists() {
-            return Err(AxisError::Other(format!(
-                "Hook {} already exists",
-                hook_type.filename()
-            )));
+            return Err(AxisError::Other(format!("Hook {hook_type} already exists")));
         }
 
         // Write the hook file
@@ -480,10 +477,7 @@ impl HookService {
         let info = self.get_hook_info(hook_type);
 
         if !info.exists {
-            return Err(AxisError::Other(format!(
-                "Hook {} does not exist",
-                hook_type.filename()
-            )));
+            return Err(AxisError::Other(format!("Hook {hook_type} does not exist")));
         }
 
         // Write the updated content
@@ -510,10 +504,7 @@ impl HookService {
         let info = self.get_hook_info(hook_type);
 
         if !info.exists {
-            return Err(AxisError::Other(format!(
-                "Hook {} does not exist",
-                hook_type.filename()
-            )));
+            return Err(AxisError::Other(format!("Hook {hook_type} does not exist")));
         }
 
         fs::remove_file(&info.path).map_err(AxisError::from)?;
@@ -522,8 +513,8 @@ impl HookService {
 
     /// Toggle hook enabled/disabled state
     pub fn toggle_hook(&self, hook_type: GitHookType) -> Result<bool> {
-        let filename = hook_type.filename();
-        let hook_path = self.hooks_path.join(filename);
+        let filename = hook_type.to_string();
+        let hook_path = self.hooks_path.join(&filename);
         let disabled_path = self.hooks_path.join(format!("{filename}.disabled"));
 
         if hook_path.exists() && hook_path.is_file() {
@@ -535,10 +526,7 @@ impl HookService {
             fs::rename(&disabled_path, &hook_path).map_err(AxisError::from)?;
             Ok(true) // Now enabled
         } else {
-            Err(AxisError::Other(format!(
-                "Hook {} does not exist",
-                hook_type.filename()
-            )))
+            Err(AxisError::Other(format!("Hook {hook_type} does not exist")))
         }
     }
 

--- a/src-tauri/tests/git_hooks.rs
+++ b/src-tauri/tests/git_hooks.rs
@@ -19,7 +19,7 @@ fn hooks_dir(path: &std::path::Path) -> std::path::PathBuf {
 
 /// Get hook file path
 fn hook_path(path: &std::path::Path, hook_type: GitHookType) -> std::path::PathBuf {
-    hooks_dir(path).join(hook_type.filename())
+    hooks_dir(path).join(hook_type.to_string())
 }
 
 /// Check if hook file exists

--- a/src/bindings/api.ts
+++ b/src/bindings/api.ts
@@ -1425,7 +1425,7 @@ prefix: string | null }
 export type ArchiveResult = { message: string; outputPath: string | null; sizeBytes: number | null }
 export type AvatarResponse = { source: AvatarSource; path: string | null }
 export type AvatarSource = "Integration" | "Gravatar" | "Default"
-export type AxisError = { type: "RepositoryNotFound"; data: string } | { type: "InvalidRepositoryPath"; data: string } | { type: "GitError"; data: string } | { type: "IoError"; data: string } | { type: "DatabaseError"; data: string } | { type: "SerializationError"; data: string } | { type: "InvalidReference"; data: string } | { type: "NoRepositoryOpen" } | { type: "BranchNotFound"; data: string } | { type: "BranchNotMerged"; data: string } | { type: "RemoteNotFound"; data: string } | { type: "FileNotFound"; data: string } | { type: "CannotFastForward" } | { type: "RebaseRequired" } | { type: "MergeConflict" } | { type: "CheckoutConflict"; data: string[] } | { type: "StashApplyConflict"; data: string[] } | { type: "AuthenticationFailed"; data: string } | { type: "AiServiceError"; data: string } | { type: "ApiKeyNotConfigured"; data: string } | { type: "DiffTooLarge"; data: number } | { type: "Other"; data: string } | { type: "IntegrationNotConnected"; data: string } | { type: "IntegrationError"; data: string } | { type: "ProviderNotDetected" } | { type: "OAuthError"; data: string } | { type: "OAuthCancelled" } | { type: "SshKeyError"; data: string } | { type: "SshKeyAlreadyExists"; data: string } | { type: "SshKeygenNotFound" } | { type: "InvalidKeyFilename"; data: string }
+export type AxisError = { type: "InvalidRepositoryPath"; data: string } | { type: "GitError"; data: string } | { type: "IoError"; data: string } | { type: "DatabaseError"; data: string } | { type: "SerializationError"; data: string } | { type: "InvalidReference"; data: string } | { type: "NoRepositoryOpen" } | { type: "BranchNotFound"; data: string } | { type: "BranchNotMerged"; data: string } | { type: "FileNotFound"; data: string } | { type: "CannotFastForward" } | { type: "RebaseRequired" } | { type: "MergeConflict" } | { type: "CheckoutConflict"; data: string[] } | { type: "StashApplyConflict"; data: string[] } | { type: "AiServiceError"; data: string } | { type: "ApiKeyNotConfigured"; data: string } | { type: "DiffTooLarge"; data: number } | { type: "Other"; data: string } | { type: "IntegrationNotConnected"; data: string } | { type: "IntegrationError"; data: string } | { type: "OAuthError"; data: string } | { type: "OAuthCancelled" } | { type: "SshKeyError"; data: string } | { type: "SshKeyAlreadyExists"; data: string } | { type: "SshKeygenNotFound" } | { type: "InvalidKeyFilename"; data: string }
 /**
  * Mark type for bisect marking operations
  */
@@ -3091,11 +3091,11 @@ export type RebaseAction = "Pick" | "Reword" | "Edit" | "Squash" | "Fixup" | "Dr
  */
 export type RebaseOntoOptions = { 
 /**
- * Target branch/commit where commits will be replayed (new_base)
+ * Target branch/commit where commits will be replayed (`new_base`)
  */
 newBase: string; 
 /**
- * Starting point - commits AFTER this point will be moved (old_base)
+ * Starting point - commits AFTER this point will be moved (`old_base`)
  */
 oldBase: string; 
 /**


### PR DESCRIPTION
## Summary
This PR refactors the `GitFlowBranchType` and `GitHookType` to utilize the `strum` library for string conversion. This change enhances code maintainability and readability across various models and services.

## Changes
- Updated `GitFlowBranchType` and `GitHookType` to use `strum` for string conversion.
- Modified the following files:
  - `src-tauri/src/models/gitflow.rs`
  - `src-tauri/src/models/hooks.rs`
  - `src-tauri/src/models/integration.rs`
  - `src-tauri/src/models/signing.rs`
  - `src-tauri/src/services/git_cli_service.rs`
  - `src-tauri/src/services/hook_service.rs`
  - `src-tauri/src/services/integrations/github/mod.rs`
  - `src-tauri/tests/git_hooks.rs`
  - `src/bindings/api.ts`