### PR TITLE
Implement drag-and-drop for tab reordering with @dnd-kit

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,6 +30,10 @@
   },
   "dependencies": {
     "@choochmeque/tauri-plugin-notifications-api": "^0.4.3",
+    "@dnd-kit/core": "^6.3.1",
+    "@dnd-kit/modifiers": "^9.0.0",
+    "@dnd-kit/sortable": "^10.0.0",
+    "@dnd-kit/utilities": "^3.2.2",
     "@radix-ui/react-checkbox": "^1.3.3",
     "@radix-ui/react-context-menu": "^2.2.0",
     "@radix-ui/react-dialog": "^1.1.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -11,6 +11,18 @@ importers:
       '@choochmeque/tauri-plugin-notifications-api':
         specifier: ^0.4.3
         version: 0.4.3
+      '@dnd-kit/core':
+        specifier: ^6.3.1
+        version: 6.3.1(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@dnd-kit/modifiers':
+        specifier: ^9.0.0
+        version: 9.0.0(@dnd-kit/core@6.3.1(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react@19.2.4)
+      '@dnd-kit/sortable':
+        specifier: ^10.0.0
+        version: 10.0.0(@dnd-kit/core@6.3.1(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react@19.2.4)
+      '@dnd-kit/utilities':
+        specifier: ^3.2.2
+        version: 3.2.2(react@19.2.4)
       '@radix-ui/react-checkbox':
         specifier: ^1.3.3
         version: 1.3.3(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
@@ -569,6 +581,34 @@ packages:
   '@csstools/css-tokenizer@4.0.0':
     resolution: {integrity: sha512-QxULHAm7cNu72w97JUNCBFODFaXpbDg+dP8b/oWFAZ2MTRppA3U00Y2L1HqaS4J6yBqxwa/Y3nMBaxVKbB/NsA==}
     engines: {node: '>=20.19.0'}
+
+  '@dnd-kit/accessibility@3.1.1':
+    resolution: {integrity: sha512-2P+YgaXF+gRsIihwwY1gCsQSYnu9Zyj2py8kY5fFvUM1qm2WA2u639R6YNVfU4GWr+ZM5mqEsfHZZLoRONbemw==}
+    peerDependencies:
+      react: '>=16.8.0'
+
+  '@dnd-kit/core@6.3.1':
+    resolution: {integrity: sha512-xkGBRQQab4RLwgXxoqETICr6S5JlogafbhNsidmrkVv2YRs5MLwpjoF2qpiGjQt8S9AoxtIV603s0GIUpY5eYQ==}
+    peerDependencies:
+      react: '>=16.8.0'
+      react-dom: '>=16.8.0'
+
+  '@dnd-kit/modifiers@9.0.0':
+    resolution: {integrity: sha512-ybiLc66qRGuZoC20wdSSG6pDXFikui/dCNGthxv4Ndy8ylErY0N3KVxY2bgo7AWwIbxDmXDg3ylAFmnrjcbVvw==}
+    peerDependencies:
+      '@dnd-kit/core': ^6.3.0
+      react: '>=16.8.0'
+
+  '@dnd-kit/sortable@10.0.0':
+    resolution: {integrity: sha512-+xqhmIIzvAYMGfBYYnbKuNicfSsk4RksY2XdmJhT+HAC01nix6fHCztU68jooFiMUB01Ky3F0FyOvhG/BZrWkg==}
+    peerDependencies:
+      '@dnd-kit/core': ^6.3.0
+      react: '>=16.8.0'
+
+  '@dnd-kit/utilities@3.2.2':
+    resolution: {integrity: sha512-+MKAJEOfaBe5SmV6t34p80MMKhjvUz0vRrvVJbPT0WElzaOJ/1xs+D+KDv+tD/NE5ujfrChEcshd4fLn0wpiqg==}
+    peerDependencies:
+      react: '>=16.8.0'
 
   '@docsearch/css@3.8.2':
     resolution: {integrity: sha512-y05ayQFyUmCXze79+56v/4HpycYF3uFqB78pLPrSV5ZKAlDuIAAJNhaRi8tTdRNXh05yxX/TyNnzD6LwSM89vQ==}
@@ -5853,6 +5893,38 @@ snapshots:
   '@csstools/css-syntax-patches-for-csstree@1.0.28': {}
 
   '@csstools/css-tokenizer@4.0.0': {}
+
+  '@dnd-kit/accessibility@3.1.1(react@19.2.4)':
+    dependencies:
+      react: 19.2.4
+      tslib: 2.8.1
+
+  '@dnd-kit/core@6.3.1(react-dom@19.2.4(react@19.2.4))(react@19.2.4)':
+    dependencies:
+      '@dnd-kit/accessibility': 3.1.1(react@19.2.4)
+      '@dnd-kit/utilities': 3.2.2(react@19.2.4)
+      react: 19.2.4
+      react-dom: 19.2.4(react@19.2.4)
+      tslib: 2.8.1
+
+  '@dnd-kit/modifiers@9.0.0(@dnd-kit/core@6.3.1(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react@19.2.4)':
+    dependencies:
+      '@dnd-kit/core': 6.3.1(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@dnd-kit/utilities': 3.2.2(react@19.2.4)
+      react: 19.2.4
+      tslib: 2.8.1
+
+  '@dnd-kit/sortable@10.0.0(@dnd-kit/core@6.3.1(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react@19.2.4)':
+    dependencies:
+      '@dnd-kit/core': 6.3.1(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@dnd-kit/utilities': 3.2.2(react@19.2.4)
+      react: 19.2.4
+      tslib: 2.8.1
+
+  '@dnd-kit/utilities@3.2.2(react@19.2.4)':
+    dependencies:
+      react: 19.2.4
+      tslib: 2.8.1
 
   '@docsearch/css@3.8.2': {}
 

--- a/src/components/layout/DraggableTab.test.tsx
+++ b/src/components/layout/DraggableTab.test.tsx
@@ -1,0 +1,159 @@
+import { fireEvent, render, screen } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { TabType, type Tab } from '@/store/tabsStore';
+
+// Mock @dnd-kit/sortable
+const mockUseSortable = vi.fn();
+vi.mock('@dnd-kit/sortable', () => ({
+  useSortable: (args: { id: string }) => mockUseSortable(args),
+}));
+
+// Mock @dnd-kit/utilities
+vi.mock('@dnd-kit/utilities', () => ({
+  // eslint-disable-next-line @typescript-eslint/naming-convention -- Matches library export
+  CSS: {
+    // eslint-disable-next-line @typescript-eslint/naming-convention -- Matches library export
+    Transform: {
+      toString: (transform: unknown) => (transform ? 'transform-string' : undefined),
+    },
+  },
+}));
+
+// Mock Radix Tabs to avoid context issues
+vi.mock('@radix-ui/react-tabs', () => ({
+  Trigger: ({
+    children,
+    className,
+    style,
+  }: {
+    children: React.ReactNode;
+    className?: string;
+    style?: React.CSSProperties;
+  }) => (
+    <div data-testid="tab-trigger" className={className} style={style}>
+      {children}
+    </div>
+  ),
+}));
+
+import { DraggableTab } from './DraggableTab';
+
+describe('DraggableTab', () => {
+  const defaultSortableReturn = {
+    attributes: { role: 'button', tabIndex: 0 },
+    listeners: { onPointerDown: vi.fn() },
+    setNodeRef: vi.fn(),
+    transform: null,
+    transition: undefined,
+    isDragging: false,
+  };
+
+  const mockTab: Tab = {
+    id: 'test-tab',
+    type: TabType.Repository,
+    name: 'Test Repo',
+    path: '/test/repo',
+    isDirty: false,
+  };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockUseSortable.mockReturnValue(defaultSortableReturn);
+  });
+
+  it('should render tab name', () => {
+    render(<DraggableTab tab={mockTab} onClose={vi.fn()} />);
+
+    expect(screen.getByText('Test Repo')).toBeInTheDocument();
+  });
+
+  it('should render close button', () => {
+    const { container } = render(<DraggableTab tab={mockTab} onClose={vi.fn()} />);
+
+    const closeButton = container.querySelector('button');
+    expect(closeButton).toBeInTheDocument();
+  });
+
+  it('should call onClose when close button is clicked', () => {
+    const onClose = vi.fn();
+    const { container } = render(<DraggableTab tab={mockTab} onClose={onClose} />);
+
+    const closeButton = container.querySelector('button');
+    fireEvent.click(closeButton!);
+
+    expect(onClose).toHaveBeenCalledWith(expect.any(Object), 'test-tab');
+  });
+
+  it('should show dirty indicator when tab is dirty', () => {
+    const dirtyTab: Tab = { ...mockTab, isDirty: true };
+    const { container } = render(<DraggableTab tab={dirtyTab} onClose={vi.fn()} />);
+
+    const dirtyIndicator = container.querySelector('.bg-blue-500.rounded-full');
+    expect(dirtyIndicator).toBeInTheDocument();
+  });
+
+  it('should not show dirty indicator when tab is not dirty', () => {
+    const { container } = render(<DraggableTab tab={mockTab} onClose={vi.fn()} />);
+
+    const dirtyIndicator = container.querySelector('.bg-blue-500.rounded-full');
+    expect(dirtyIndicator).not.toBeInTheDocument();
+  });
+
+  it('should apply dragging class when isDragging is true', () => {
+    mockUseSortable.mockReturnValue({
+      ...defaultSortableReturn,
+      isDragging: true,
+    });
+
+    render(<DraggableTab tab={mockTab} onClose={vi.fn()} />);
+
+    const trigger = screen.getByTestId('tab-trigger');
+    expect(trigger.className).toContain('tab-dragging');
+  });
+
+  it('should not apply dragging class when isDragging is false', () => {
+    render(<DraggableTab tab={mockTab} onClose={vi.fn()} />);
+
+    const trigger = screen.getByTestId('tab-trigger');
+    expect(trigger.className).not.toContain('tab-dragging');
+  });
+
+  it('should pass transform and transition from useSortable to style', () => {
+    const mockTransform = { x: 10, y: 0, scaleX: 1, scaleY: 1 };
+    const mockTransition = 'transform 200ms ease';
+
+    mockUseSortable.mockReturnValue({
+      ...defaultSortableReturn,
+      transform: mockTransform,
+      transition: mockTransition,
+    });
+
+    render(<DraggableTab tab={mockTab} onClose={vi.fn()} />);
+
+    // Verify useSortable was called and its values would be used
+    expect(mockUseSortable).toHaveBeenCalledWith({ id: 'test-tab' });
+
+    const trigger = screen.getByTestId('tab-trigger');
+    // The transition should be applied (transform depends on CSS.Transform.toString mock)
+    expect(trigger.style.transition).toBe(mockTransition);
+  });
+
+  it('should call useSortable with tab id', () => {
+    render(<DraggableTab tab={mockTab} onClose={vi.fn()} />);
+
+    expect(mockUseSortable).toHaveBeenCalledWith({ id: 'test-tab' });
+  });
+
+  it('should stop pointer event propagation on close button', () => {
+    const { container } = render(<DraggableTab tab={mockTab} onClose={vi.fn()} />);
+
+    const closeButton = container.querySelector('button');
+    const pointerDownEvent = new PointerEvent('pointerdown', { bubbles: true });
+    const stopPropagationSpy = vi.spyOn(pointerDownEvent, 'stopPropagation');
+
+    fireEvent(closeButton!, pointerDownEvent);
+
+    expect(stopPropagationSpy).toHaveBeenCalled();
+  });
+});

--- a/src/components/layout/DraggableTab.tsx
+++ b/src/components/layout/DraggableTab.tsx
@@ -1,0 +1,70 @@
+import { useSortable } from '@dnd-kit/sortable';
+import { CSS } from '@dnd-kit/utilities';
+import * as Tabs from '@radix-ui/react-tabs';
+import { X } from 'lucide-react';
+
+import { cn } from '@/lib/utils';
+import { type Tab } from '@/store/tabsStore';
+
+interface DraggableTabProps {
+  tab: Tab;
+  onClose: (e: React.MouseEvent, tabId: string) => void;
+}
+
+export function DraggableTab({ tab, onClose }: DraggableTabProps) {
+  const { attributes, listeners, setNodeRef, transform, transition, isDragging } = useSortable({
+    id: tab.id,
+  });
+
+  const style = {
+    transform: CSS.Transform.toString(transform),
+    transition,
+  };
+
+  return (
+    <Tabs.Trigger
+      ref={setNodeRef}
+      style={style}
+      value={tab.id}
+      asChild
+      className={cn(
+        'group flex items-center gap-2 h-full px-3 border-r border-(--border-color) cursor-grab transition-colors min-w-0',
+        'hover:bg-(--bg-hover)',
+        'data-[state=active]:bg-(--bg-primary) data-[state=active]:border-b-2 data-[state=active]:border-b-(--accent-color)',
+        'data-[state=inactive]:bg-(--bg-toolbar)',
+        isDragging && 'tab-dragging'
+      )}
+    >
+      <div {...attributes} {...listeners}>
+        <div className="relative shrink-0">
+          <svg width={14} height={14}>
+            <circle
+              cx={7}
+              cy={7}
+              r={5}
+              fill="var(--bg-toolbar)"
+              stroke="var(--accent-color)"
+              strokeWidth={2}
+            />
+          </svg>
+          {tab.isDirty && (
+            <span className="absolute -top-0.5 -right-0.5 w-2 h-2 bg-blue-500 rounded-full" />
+          )}
+        </div>
+        <span className="text-base text-(--text-primary) truncate max-w-40">{tab.name}</span>
+        <button
+          className={cn(
+            'flex items-center justify-center w-4 h-4 rounded shrink-0 transition-colors',
+            'text-(--text-tertiary) hover:text-(--text-primary) hover:bg-(--bg-active)',
+            'opacity-0 group-hover:opacity-100',
+            'group-data-[state=active]:opacity-100'
+          )}
+          onClick={(e) => onClose(e, tab.id)}
+          onPointerDown={(e) => e.stopPropagation()}
+        >
+          <X size={12} />
+        </button>
+      </div>
+    </Tabs.Trigger>
+  );
+}

--- a/src/components/layout/TabBar.test.tsx
+++ b/src/components/layout/TabBar.test.tsx
@@ -5,6 +5,7 @@ import { TabBar } from './TabBar';
 
 const mockRemoveTab = vi.fn();
 const mockSetActiveTab = vi.fn();
+const mockReorderTabs = vi.fn();
 const mockClearRepoCache = vi.fn();
 const mockClearIntegrationCache = vi.fn();
 const mockClearStagingCache = vi.fn();
@@ -23,8 +24,48 @@ vi.mock('@/store/tabsStore', () => ({
     activeTabId: mockActiveTabId,
     setActiveTab: mockSetActiveTab,
     removeTab: mockRemoveTab,
+    reorderTabs: mockReorderTabs,
   }),
 }));
+
+/* eslint-disable @typescript-eslint/naming-convention */
+// Mock @dnd-kit
+vi.mock('@dnd-kit/core', () => ({
+  DndContext: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+  DragOverlay: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+  closestCenter: vi.fn(),
+  KeyboardSensor: vi.fn(),
+  PointerSensor: vi.fn(),
+  useSensor: vi.fn(),
+  useSensors: vi.fn(() => []),
+}));
+
+vi.mock('@dnd-kit/sortable', () => ({
+  SortableContext: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+  horizontalListSortingStrategy: vi.fn(),
+  sortableKeyboardCoordinates: vi.fn(),
+  useSortable: () => ({
+    attributes: {},
+    listeners: {},
+    setNodeRef: vi.fn(),
+    transform: null,
+    transition: undefined,
+    isDragging: false,
+  }),
+}));
+
+vi.mock('@dnd-kit/utilities', () => ({
+  CSS: {
+    Transform: {
+      toString: () => undefined,
+    },
+  },
+}));
+
+vi.mock('@dnd-kit/modifiers', () => ({
+  restrictToHorizontalAxis: vi.fn(),
+}));
+/* eslint-enable @typescript-eslint/naming-convention */
 
 vi.mock('@/store/repositoryStore', () => ({
   useRepositoryStore: {
@@ -230,5 +271,40 @@ describe('TabBar tab switching', () => {
 
     expect(screen.getByText('Tab 1')).toBeInTheDocument();
     expect(screen.getByText('Tab 2')).toBeInTheDocument();
+  });
+});
+
+describe('TabBar drag and drop', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockTabs = [
+      { id: 'welcome', name: 'Welcome', type: 'welcome', path: null, isDirty: false },
+      { id: 'tab1', name: 'Repo 1', type: 'repository', path: '/path/1', isDirty: false },
+      { id: 'tab2', name: 'Repo 2', type: 'repository', path: '/path/2', isDirty: false },
+      { id: 'tab3', name: 'Repo 3', type: 'repository', path: '/path/3', isDirty: false },
+    ];
+    mockActiveTabId = 'tab1';
+  });
+
+  it('should render repository tabs as draggable', () => {
+    render(<TabBar onTabChange={vi.fn()} />);
+
+    // All repository tabs should be rendered
+    expect(screen.getByText('Repo 1')).toBeInTheDocument();
+    expect(screen.getByText('Repo 2')).toBeInTheDocument();
+    expect(screen.getByText('Repo 3')).toBeInTheDocument();
+  });
+
+  it('should render Welcome tab separately (not draggable)', () => {
+    render(<TabBar onTabChange={vi.fn()} />);
+
+    expect(screen.getByText('Welcome')).toBeInTheDocument();
+  });
+
+  it('should have reorderTabs function available from store', () => {
+    render(<TabBar onTabChange={vi.fn()} />);
+
+    // Verify mock is set up (function exists)
+    expect(mockReorderTabs).toBeDefined();
   });
 });

--- a/src/components/layout/TabBar.tsx
+++ b/src/components/layout/TabBar.tsx
@@ -1,5 +1,24 @@
+import {
+  closestCenter,
+  DndContext,
+  DragOverlay,
+  KeyboardSensor,
+  PointerSensor,
+  useSensor,
+  useSensors,
+  type DragEndEvent,
+  type DragStartEvent,
+} from '@dnd-kit/core';
+import { restrictToHorizontalAxis } from '@dnd-kit/modifiers';
+import {
+  horizontalListSortingStrategy,
+  SortableContext,
+  sortableKeyboardCoordinates,
+} from '@dnd-kit/sortable';
 import * as Tabs from '@radix-ui/react-tabs';
 import { Home, X } from 'lucide-react';
+import { useState } from 'react';
+
 import { commands } from '@/bindings/api';
 import { cn } from '@/lib/utils';
 import { useIntegrationStore } from '@/store/integrationStore';
@@ -7,12 +26,26 @@ import { useRepositoryStore } from '@/store/repositoryStore';
 import { useStagingStore } from '@/store/stagingStore';
 import { type Tab, TabType, useTabsStore } from '@/store/tabsStore';
 
+import { DraggableTab } from './DraggableTab';
+
 interface TabBarProps {
   onTabChange: (tab: Tab) => void;
 }
 
 export function TabBar({ onTabChange }: TabBarProps) {
-  const { tabs, activeTabId, setActiveTab, removeTab } = useTabsStore();
+  const { tabs, activeTabId, setActiveTab, removeTab, reorderTabs } = useTabsStore();
+  const [draggedTab, setDraggedTab] = useState<Tab | null>(null);
+
+  const sensors = useSensors(
+    useSensor(PointerSensor, {
+      activationConstraint: {
+        distance: 8,
+      },
+    }),
+    useSensor(KeyboardSensor, {
+      coordinateGetter: sortableKeyboardCoordinates,
+    })
+  );
 
   // Hide tab bar when only 1 tab
   if (tabs.length <= 1) {
@@ -43,13 +76,38 @@ export function TabBar({ onTabChange }: TabBarProps) {
     removeTab(tabId);
   };
 
+  const handleDragStart = (event: DragStartEvent) => {
+    const { active } = event;
+    const tab = tabs.find((t) => t.id === active.id);
+    if (tab) {
+      setDraggedTab(tab);
+    }
+  };
+
+  const handleDragEnd = (event: DragEndEvent) => {
+    const { active, over } = event;
+    setDraggedTab(null);
+
+    if (over && active.id !== over.id) {
+      reorderTabs(String(active.id), String(over.id));
+    }
+  };
+
+  const handleDragCancel = () => {
+    setDraggedTab(null);
+  };
+
+  const welcomeTab = tabs.find((t) => t.type === TabType.Welcome);
+  const repoTabs = tabs.filter((t) => t.type === TabType.Repository);
+  const sortableIds = repoTabs.map((t) => t.id);
+
   return (
     <Tabs.Root value={activeTabId} onValueChange={handleTabChange}>
       <Tabs.List className="flex items-center h-9 bg-(--bg-toolbar) border-b border-(--border-color) overflow-x-auto">
-        {tabs.map((tab) => (
+        {/* Welcome tab - not draggable */}
+        {welcomeTab && (
           <Tabs.Trigger
-            key={tab.id}
-            value={tab.id}
+            value={welcomeTab.id}
             asChild
             className={cn(
               'group flex items-center gap-2 h-full px-3 border-r border-(--border-color) cursor-pointer transition-colors min-w-0',
@@ -59,9 +117,32 @@ export function TabBar({ onTabChange }: TabBarProps) {
             )}
           >
             <div>
-              {tab.type === TabType.Welcome ? (
-                <Home size={14} className="shrink-0 text-(--text-secondary)" />
-              ) : (
+              <Home size={14} className="shrink-0 text-(--text-secondary)" />
+              <span className="text-base text-(--text-primary) truncate max-w-40">
+                {welcomeTab.name}
+              </span>
+            </div>
+          </Tabs.Trigger>
+        )}
+
+        {/* Draggable repository tabs */}
+        <DndContext
+          sensors={sensors}
+          collisionDetection={closestCenter}
+          modifiers={[restrictToHorizontalAxis]}
+          onDragStart={handleDragStart}
+          onDragEnd={handleDragEnd}
+          onDragCancel={handleDragCancel}
+        >
+          <SortableContext items={sortableIds} strategy={horizontalListSortingStrategy}>
+            {repoTabs.map((tab) => (
+              <DraggableTab key={tab.id} tab={tab} onClose={handleCloseTab} />
+            ))}
+          </SortableContext>
+
+          <DragOverlay>
+            {draggedTab && (
+              <div className="tab-drag-overlay flex items-center gap-2 h-9 px-3">
                 <div className="relative shrink-0">
                   <svg width={14} height={14}>
                     <circle
@@ -73,28 +154,18 @@ export function TabBar({ onTabChange }: TabBarProps) {
                       strokeWidth={2}
                     />
                   </svg>
-                  {tab.isDirty && (
+                  {draggedTab.isDirty && (
                     <span className="absolute -top-0.5 -right-0.5 w-2 h-2 bg-blue-500 rounded-full" />
                   )}
                 </div>
-              )}
-              <span className="text-base text-(--text-primary) truncate max-w-40">{tab.name}</span>
-              {tab.type !== TabType.Welcome && (
-                <button
-                  className={cn(
-                    'flex items-center justify-center w-4 h-4 rounded shrink-0 transition-colors',
-                    'text-(--text-tertiary) hover:text-(--text-primary) hover:bg-(--bg-active)',
-                    'opacity-0 group-hover:opacity-100',
-                    'group-data-[state=active]:opacity-100'
-                  )}
-                  onClick={(e) => handleCloseTab(e, tab.id)}
-                >
-                  <X size={12} />
-                </button>
-              )}
-            </div>
-          </Tabs.Trigger>
-        ))}
+                <span className="text-base text-(--text-primary) truncate max-w-40">
+                  {draggedTab.name}
+                </span>
+                <X size={12} className="text-(--text-tertiary)" />
+              </div>
+            )}
+          </DragOverlay>
+        </DndContext>
       </Tabs.List>
     </Tabs.Root>
   );

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -1074,6 +1074,12 @@
       "changes": "{{count}} changes",
       "clean": "Clean",
       "loading": "Loading..."
+    },
+    "tabs": {
+      "dragToReorder": "Drag to reorder tabs",
+      "pickedUp": "Picked up {{name}}",
+      "dropped": "Dropped {{name}} at position {{position}}",
+      "cancelled": "Reorder cancelled"
     }
   },
   "sidebar": {

--- a/src/index.css
+++ b/src/index.css
@@ -1401,3 +1401,23 @@ code {
   gap: 0.125rem;
   flex-shrink: 0;
 }
+
+/* Tab Drag and Drop */
+.tab-dragging {
+  opacity: 0.5;
+}
+
+.tab-drag-overlay {
+  background: var(--bg-primary);
+  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.3);
+  border: 2px solid var(--accent-color);
+  border-radius: 4px;
+  cursor: grabbing;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .tab-dragging,
+  .tab-drag-overlay {
+    transition: none;
+  }
+}

--- a/src/store/tabsStore.test.ts
+++ b/src/store/tabsStore.test.ts
@@ -272,4 +272,88 @@ describe('tabsStore', () => {
       expect(tab?.isDirty).toBe(false);
     });
   });
+
+  describe('reorderTabs', () => {
+    it('should reorder tabs correctly', () => {
+      const id1 = useTabsStore.getState().addTab({
+        type: TabType.Repository,
+        name: 'Repo 1',
+        path: '/repo1',
+      });
+      const id2 = useTabsStore.getState().addTab({
+        type: TabType.Repository,
+        name: 'Repo 2',
+        path: '/repo2',
+      });
+      const id3 = useTabsStore.getState().addTab({
+        type: TabType.Repository,
+        name: 'Repo 3',
+        path: '/repo3',
+      });
+
+      // Move Repo 3 to position of Repo 1
+      useTabsStore.getState().reorderTabs(id3, id1);
+
+      const state = useTabsStore.getState();
+      expect(state.tabs[0].id).toBe('welcome');
+      expect(state.tabs[1].id).toBe(id3);
+      expect(state.tabs[2].id).toBe(id1);
+      expect(state.tabs[3].id).toBe(id2);
+    });
+
+    it('should not move Welcome tab', () => {
+      const id1 = useTabsStore.getState().addTab({
+        type: TabType.Repository,
+        name: 'Repo 1',
+        path: '/repo1',
+      });
+
+      useTabsStore.getState().reorderTabs('welcome', id1);
+
+      const state = useTabsStore.getState();
+      expect(state.tabs[0].id).toBe('welcome');
+      expect(state.tabs[1].id).toBe(id1);
+    });
+
+    it('should not move tab to Welcome position', () => {
+      const id1 = useTabsStore.getState().addTab({
+        type: TabType.Repository,
+        name: 'Repo 1',
+        path: '/repo1',
+      });
+
+      useTabsStore.getState().reorderTabs(id1, 'welcome');
+
+      const state = useTabsStore.getState();
+      expect(state.tabs[0].id).toBe('welcome');
+      expect(state.tabs[1].id).toBe(id1);
+    });
+
+    it('should handle same id gracefully', () => {
+      const id1 = useTabsStore.getState().addTab({
+        type: TabType.Repository,
+        name: 'Repo 1',
+        path: '/repo1',
+      });
+
+      useTabsStore.getState().reorderTabs(id1, id1);
+
+      const state = useTabsStore.getState();
+      expect(state.tabs).toHaveLength(2);
+      expect(state.tabs[1].id).toBe(id1);
+    });
+
+    it('should handle invalid ids gracefully', () => {
+      useTabsStore.getState().addTab({
+        type: TabType.Repository,
+        name: 'Repo 1',
+        path: '/repo1',
+      });
+
+      useTabsStore.getState().reorderTabs('non-existent', 'also-non-existent');
+
+      const state = useTabsStore.getState();
+      expect(state.tabs).toHaveLength(2);
+    });
+  });
 });

--- a/src/store/tabsStore.ts
+++ b/src/store/tabsStore.ts
@@ -1,3 +1,4 @@
+import { arrayMove } from '@dnd-kit/sortable';
 import { create, type StateCreator } from 'zustand';
 import { createJSONStorage, persist } from 'zustand/middleware';
 
@@ -24,6 +25,7 @@ interface TabsState {
   findTabByPath: (path: string) => Tab | undefined;
   markTabDirty: (path: string) => void;
   clearTabDirty: (path: string) => void;
+  reorderTabs: (activeId: string, overId: string) => void;
 }
 
 const generateId = () => Math.random().toString(36).substring(2, 9);
@@ -144,6 +146,22 @@ const createTabsSlice: StateCreator<TabsState> = (set, get) => ({
         tab.path && normalizePath(tab.path) === key ? { ...tab, isDirty: false } : tab
       ),
     }));
+  },
+
+  reorderTabs: (activeId, overId) => {
+    if (activeId === overId) return;
+
+    const { tabs } = get();
+    const oldIndex = tabs.findIndex((t) => t.id === activeId);
+    const newIndex = tabs.findIndex((t) => t.id === overId);
+
+    // Invalid indices
+    if (oldIndex === -1 || newIndex === -1) return;
+
+    // Prevent moving Welcome tab (index 0) or moving to Welcome position
+    if (oldIndex === 0 || newIndex === 0) return;
+
+    set({ tabs: arrayMove(tabs, oldIndex, newIndex) });
   },
 });
 


### PR DESCRIPTION
## Summary
This PR introduces drag-and-drop functionality for reordering tabs using the `@dnd-kit` components. It enhances the user experience by allowing users to easily rearrange their tabs through intuitive drag-and-drop interactions.

## Changes
- **Added** drag-and-drop functionality in `DraggableTab.tsx` for tab reordering.
- **Updated** tests in `DraggableTab.test.tsx` to cover new functionality.
- **Modified** existing `TabBar` components and tests to integrate drag-and-drop.
- **Updated** localization files in `en.json` to reflect any UI changes.
- **Adjusted** styles in `index.css` to ensure proper layout for draggable tabs.