### PR TITLE
Fix clippy lint: use is_ok_and in hook_service test

### DIFF
--- a/src-tauri/src/services/hook_service.rs
+++ b/src-tauri/src/services/hook_service.rs
@@ -587,8 +587,7 @@ mod tests {
         assert!(
             actual_path
                 .canonicalize()
-                .ok()
-                .is_some_and(|p| expected_path.canonicalize().ok().is_some_and(|e| p == e))
+                .is_ok_and(|p| expected_path.canonicalize().is_ok_and(|e| p == e))
                 || actual_path == expected_path
         );
         assert!(service.hooks_path.ends_with("hooks"));


### PR DESCRIPTION
`rust-toolchain@stable` moved to 1.98 (2026-08-18), which adds a lint for `.ok().is_some_and(..)` on a `Result`. `main` last ran Checks on 2026-07-15 and is red under the current stable; every open PR (e.g. #291) now fails `check-cargo` on this line.

Two occurrences in the same assertion in `hook_service.rs` tests, rewritten to `is_ok_and`. No behaviour change.