### PR TITLE
Bump notifications API to 0.5.0-rc.13

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "docs:preview": "vitepress preview docs"
   },
   "dependencies": {
-    "@choochmeque/tauri-plugin-notifications-api": "0.5.0-rc.11",
+    "@choochmeque/tauri-plugin-notifications-api": "0.5.0-rc.13",
     "@dnd-kit/core": "^6.3.1",
     "@dnd-kit/modifiers": "^9.0.0",
     "@dnd-kit/sortable": "^10.0.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -9,8 +9,8 @@ importers:
   .:
     dependencies:
       '@choochmeque/tauri-plugin-notifications-api':
-        specifier: 0.5.0-rc.11
-        version: 0.5.0-rc.11
+        specifier: 0.5.0-rc.13
+        version: 0.5.0-rc.13
       '@dnd-kit/core':
         specifier: ^6.3.1
         version: 6.3.1(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
@@ -494,8 +494,8 @@ packages:
     resolution: {integrity: sha512-ctxtJ/eA+t+6q2++vj5j7FYX3nRu311q1wfYH3xjlLOsczhlhxAg2FWNUXhpGvAw3BWo1xBcvOV6/YLc2r5FJw==}
     hasBin: true
 
-  '@choochmeque/tauri-plugin-notifications-api@0.5.0-rc.11':
-    resolution: {integrity: sha512-TSuf8HQ4Ayp9IKKB5v2yTdgKMa/I0bqbcACj0IZ46CSpzn/HKner/BKG7rM8tGOarEcyBd/VXnDhK5cJA/YMtw==}
+  '@choochmeque/tauri-plugin-notifications-api@0.5.0-rc.13':
+    resolution: {integrity: sha512-F+zQGsJuElZSyKi1RBSaOI5WydoNeJb4/KfrsyOT4SQMM2E/SNEhiknVmyiyGUYIAQKuMjmk++n4Jj82H9aQtQ==}
 
   '@cspotcode/source-map-support@0.8.1':
     resolution: {integrity: sha512-IchNf6dN4tHoMFIn/7OE8LWZ19Y6q/67Bmf6vnGREv8RSbBVb9LPJxEcnwrcwX6ixSvaiGoomAUvu4YSxXrVgw==}
@@ -5970,7 +5970,7 @@ snapshots:
     dependencies:
       css-tree: 3.2.1
 
-  '@choochmeque/tauri-plugin-notifications-api@0.5.0-rc.11':
+  '@choochmeque/tauri-plugin-notifications-api@0.5.0-rc.13':
     dependencies:
       '@tauri-apps/api': 2.11.1
 


### PR DESCRIPTION
Bumps the exact-pinned notifications API to 0.5.0-rc.13: desktop click handlers on the notify-rust backend and the wry feature-gating fix.