### PR TITLE
Verify main on push and streamline CI setup

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -3,10 +3,19 @@ name: Checks
 
 on:
   pull_request:
+  push:
+    branches: [main]
   workflow_dispatch:
 
 permissions:
   contents: read
+
+concurrency:
+  # Superseded runs cancel per workflow+ref (PR merge refs and branch pushes
+  # alike); main is pinned to a unique group (run_id) so every commit on main
+  # gets its own uncancellable verification run.
+  group: ${{ github.workflow }}-${{ github.ref == 'refs/heads/main' && github.run_id || github.ref }}
+  cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
 
 jobs:
   check-pnpm:
@@ -72,16 +81,10 @@ jobs:
           workspaces: src-tauri
           shared-key: rust-${{ runner.os }}-debug
 
-      - name: Refresh APT package index
+      - uses: Choochmeque/reusable-actions/actions/setup-linux-deps@v1
         if: runner.os == 'Linux'
-        run: sudo apt-get update
-
-      - name: Cache and install APT packages
-        if: runner.os == 'Linux'
-        uses: awalsh128/cache-apt-pkgs-action@latest
         with:
           packages: libglib2.0 libwebkit2gtk-4.1-dev libappindicator3-dev librsvg2-dev patchelf cmake libwayland-dev libfuse2
-          version: '1.4'
 
       - name: Check formatting
         run: cargo fmt --all --manifest-path src-tauri/Cargo.toml -- --check

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -40,15 +40,9 @@ jobs:
           workspaces: src-tauri
           shared-key: rust-${{ runner.os }}-e2e
 
-      - name: Refresh APT package index
-        if: runner.os == 'Linux'
-        run: sudo apt-get update
-
-      - name: Cache and install APT packages
-        uses: awalsh128/cache-apt-pkgs-action@latest
+      - uses: Choochmeque/reusable-actions/actions/setup-linux-deps@v1
         with:
           packages: libglib2.0 libwebkit2gtk-4.1-dev libappindicator3-dev librsvg2-dev patchelf cmake libwayland-dev libfuse2 webkit2gtk-driver xvfb
-          version: '1.4'
 
       # Install separately - needs post-install scripts to run
       - name: Install gsettings-desktop-schemas

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -10,6 +10,13 @@ on:
 permissions:
   contents: read
 
+concurrency:
+  # Superseded runs cancel per workflow+ref (PR merge refs and branch pushes
+  # alike); main is pinned to a unique group (run_id) so every commit on main
+  # gets its own uncancellable verification run.
+  group: ${{ github.workflow }}-${{ github.ref == 'refs/heads/main' && github.run_id || github.ref }}
+  cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
+
 jobs:
   integration-tests:
     strategy:
@@ -32,16 +39,10 @@ jobs:
           workspaces: src-tauri
           shared-key: rust-${{ runner.os }}-debug
 
-      - name: Refresh APT package index
+      - uses: Choochmeque/reusable-actions/actions/setup-linux-deps@v1
         if: runner.os == 'Linux'
-        run: sudo apt-get update
-
-      - name: Cache and install APT packages
-        if: runner.os == 'Linux'
-        uses: awalsh128/cache-apt-pkgs-action@latest
         with:
           packages: libglib2.0 libwebkit2gtk-4.1-dev libappindicator3-dev librsvg2-dev patchelf cmake libwayland-dev libfuse2
-          version: '1.4'
 
       - name: Create .env file
         shell: bash

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -103,16 +103,10 @@ jobs:
           workspaces: src-tauri
           shared-key: rust-${{ runner.os }}-release
 
-      - name: Refresh APT package index
-        if: runner.os == 'Linux'
-        run: sudo apt-get update
-
-      - name: Cache and install APT packages
+      - uses: Choochmeque/reusable-actions/actions/setup-linux-deps@v1
         if: matrix.os == 'ubuntu-latest'
-        uses: awalsh128/cache-apt-pkgs-action@latest
         with:
           packages: libglib2.0 libwebkit2gtk-4.1-dev libappindicator3-dev librsvg2-dev patchelf cmake libwayland-dev libfuse2
-          version: '1.4'
 
       - name: Install frontend dependencies
         run: pnpm install --frozen-lockfile

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -64,16 +64,10 @@ jobs:
           workspaces: src-tauri
           shared-key: rust-${{ runner.os }}-release
 
-      - name: Refresh APT package index
-        if: runner.os == 'Linux'
-        run: sudo apt-get update
-
-      - name: Cache and install APT packages
+      - uses: Choochmeque/reusable-actions/actions/setup-linux-deps@v1
         if: matrix.os == 'ubuntu-latest'
-        uses: awalsh128/cache-apt-pkgs-action@latest
         with:
           packages: libglib2.0 libwebkit2gtk-4.1-dev libappindicator3-dev librsvg2-dev patchelf cmake libwayland-dev libfuse2
-          version: '1.4'
 
       - name: Install frontend dependencies
         run: pnpm install --frozen-lockfile

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -3,14 +3,19 @@ name: Unit Tests
 
 on:
   pull_request:
+  push:
+    branches: [main]
   workflow_dispatch:
 
 permissions:
   contents: read
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: true
+  # Superseded runs cancel per workflow+ref (PR merge refs and branch pushes
+  # alike); main is pinned to a unique group (run_id) so every commit on main
+  # gets its own uncancellable verification run.
+  group: ${{ github.workflow }}-${{ github.ref == 'refs/heads/main' && github.run_id || github.ref }}
+  cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
 
 jobs:
   test-pnpm:
@@ -82,16 +87,10 @@ jobs:
           workspaces: src-tauri
           shared-key: rust-${{ runner.os }}-debug
 
-      - name: Refresh APT package index
+      - uses: Choochmeque/reusable-actions/actions/setup-linux-deps@v1
         if: runner.os == 'Linux'
-        run: sudo apt-get update
-
-      - name: Cache and install APT packages
-        if: runner.os == 'Linux'
-        uses: awalsh128/cache-apt-pkgs-action@latest
         with:
           packages: libglib2.0 libwebkit2gtk-4.1-dev libappindicator3-dev librsvg2-dev patchelf cmake libwayland-dev libfuse2
-          version: '1.4'
 
       - name: Create .env file
         shell: bash


### PR DESCRIPTION
CI hygiene, no behavior change to any job's actual work:

- `checks.yml` and `tests.yml` now also run on pushes to `main`, so every commit on `main` gets verified (until now they only ran on PRs, leaving `main` unchecked between the nightly cron and release tags).
- Concurrency guards on `checks.yml`, `tests.yml` and `integration.yml`: superseded PR runs cancel; runs on `main` are pinned to a unique group so they can never be cancelled by a follow-up push.
- The six identical inline Linux apt-install blocks are replaced by the `reusable-actions` `setup-linux-deps` composite with the same package lists (e2e keeps its separate `gsettings-desktop-schemas` step, which needs post-install scripts). Linux-only matrix guards preserved.